### PR TITLE
Improve delays to sleep only during needed time

### DIFF
--- a/instabot/bot/bot.py
+++ b/instabot/bot/bot.py
@@ -80,6 +80,15 @@ class Bot(API):
         self.total_unblocked = 0
         self.start_time = datetime.datetime.now()
 
+        # the time.time() of the last action
+        self.last_like = 0
+        self.last_unlike = 0
+        self.last_follow = 0
+        self.last_unfollow = 0
+        self.last_comment = 0
+        self.last_block = 0
+        self.last_unblock = 0
+
         # limits - follow
         self.filter_users = filter_users
         self.max_likes_per_day = max_likes_per_day

--- a/instabot/bot/delay.py
+++ b/instabot/bot/delay.py
@@ -10,32 +10,47 @@ def add_dispersion(delay_value):
     return delay_value * 3 / 4 + delay_value * random.random() / 2
 
 
+# this function will sleep only if elapsed time since `last_action` is less than `target_delay`
+def sleep_if_need(last_action, target_delay):
+    now = time.time()
+    elapsed_time = now - last_action
+    if (elapsed_time < target_delay):
+        remains_to_wait = target_delay - elapsed_time
+        time.sleep(add_dispersion(remains_to_wait))
+
 def like_delay(bot):
-    time.sleep(add_dispersion(bot.like_delay))
+    sleep_if_need(bot.last_like, bot.like_delay)
+    bot.last_like = time.time()
 
 
 def unlike_delay(bot):
-    time.sleep(add_dispersion(bot.unlike_delay))
+    sleep_if_need(bot.last_unlike, bot.unlike_delay)
+    bot.last_unlike = time.time()
 
 
 def follow_delay(bot):
-    time.sleep(add_dispersion(bot.follow_delay))
+    sleep_if_need(bot.last_follow, bot.follow_delay)
+    bot.last_follow = time.time()
 
 
 def unfollow_delay(bot):
-    time.sleep(add_dispersion(bot.unfollow_delay))
+    sleep_if_need(bot.last_unfollow, bot.unfollow_delay)
+    bot.last_unfollow = time.time()
 
 
 def comment_delay(bot):
-    time.sleep(add_dispersion(bot.comment_delay))
+    sleep_if_need(bot.last_comment, bot.comment_delay)
+    bot.last_comment = time.time()
 
 
 def block_delay(bot):
-    time.sleep(add_dispersion(bot.block_delay))
+    sleep_if_need(bot.last_block, bot.block_delay)
+    bot.last_block = time.time()
 
 
 def unblock_delay(bot):
-    time.sleep(add_dispersion(bot.unblock_delay))
+    sleep_if_need(bot.last_unblock, bot.unblock_delay)
+    bot.last_unblock = time.time()
 
 
 def error_delay(bot):

--- a/instabot/bot/delay.py
+++ b/instabot/bot/delay.py
@@ -18,6 +18,7 @@ def sleep_if_need(last_action, target_delay):
         remains_to_wait = target_delay - elapsed_time
         time.sleep(add_dispersion(remains_to_wait))
 
+
 def like_delay(bot):
     sleep_if_need(bot.last_like, bot.like_delay)
     bot.last_like = time.time()


### PR DESCRIPTION
**Context:**
We want to separate likes from each other by `like_delay`;
Currently the bot sleeps for this delay always, even if the elapsed time since the last like is already greater than the delay;
**This pull requests ensures that the bot will sleep only if needed.**

**Why it's good ?**
Because we can now mix and match actions and wait less overall while still ensuring the bot won't be banned by Instagram.

**1) For instance**, with a `like_delay=10` and `follow_delay=30`
We can do the sequence of actions: `follow; like; like; like; follow` in ~30 seconds instead of ~60 seconds.

**2) Another example**:
Suppose we want to like the first media of a list of tags,
Suppose that fetching the medias for each tag takes ~3s,
Suppose `like_delay=10`,
The overall time before the pull-request is: `3* (3s + 10s)`
The overall time after the pull-request is `3*10s` since the 3s are accounted by the new method

**Only 31 lines**