### PR TITLE
I added examples for direct messaging. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 secret.txt
 
 # Files with downloaded data
-*.csv
 *.tsv
 
 # Photos

--- a/examples/message_users.py
+++ b/examples/message_users.py
@@ -1,0 +1,50 @@
+"""
+    instabot example
+
+    Workflow:
+    1) Ask Message type
+    2) Load messages CSV (if needed)
+    3) Send message to each users
+
+"""
+
+import sys
+import os
+import csv
+import time
+
+sys.path.append(os.path.join(sys.path[0], '../'))
+from instabot import Bot
+
+instaUsers = ["R1B4Z01D","KoanMedia"];
+directMessage = ["Thanks for the example."];
+
+messagesToSend = 100
+banDelay = (86400/messagesToSend)
+
+print("Which type of delivery method? (Type number)")
+print("%d: %s" % (0, "Messages From CSV File."))
+print("%d: %s" % (1, "Group Message All Users From List."))
+print("%d: %s" % (2, "Message Each User From List."))
+
+deliveryMethod = int(sys.stdin.readline())
+
+bot = Bot()
+bot.login()
+
+if deliveryMethod == 0:
+	with open('messages.csv', 'rU') as f:
+	    reader = csv.reader(f)
+	    for row in reader:
+	    	print 'Messaging ' + row[0]
+	    	bot.send_message(row[1], row[0])
+	    	print 'Waiting ' + str(banDelay) + ' seconds...'
+	    	time.sleep(banDelay)
+elif deliveryMethod == 1:
+	bot.send_message(directMessage, instaUsers)
+	print('Sent A Group Message To All Users..')
+elif deliveryMethod == 2:
+	bot.send_messages(directMessage, instaUsers)
+	print('Sent An Individual Messages To All Users..')
+else:
+	print('Invalid Selection.')

--- a/examples/messages.csv
+++ b/examples/messages.csv
@@ -1,0 +1,2 @@
+R1B4Z01D, "Thank You for the example."
+koanmedia, "I love your work."


### PR DESCRIPTION
I added two files examples/message_users.py and examples/messages.csv. The example provides the different options for messaging:

1. A single message sent to a group of users, 
2. A single message sent individually to each user.
3. A separate message to each user using a CSV data file. 

The user is asked when what option they want to use when running the example. I have been using this myself and have been testing it for a couple weeks with no known bugs. There is a variable for the number of messages to be sent in a 24 hour window. The 100 messages a day has been a happy medium for not getting baned. 