### PR TITLE
User can now set 'verbosity' variable to False to print less …

### DIFF
--- a/instabot/bot/bot.py
+++ b/instabot/bot/bot.py
@@ -49,7 +49,6 @@ from .bot_stats import save_user_stats
 
 
 class Bot(API):
-
     def __init__(self,
                  whitelist=False,
                  blacklist=False,
@@ -79,7 +78,9 @@ class Bot(API):
                  comment_delay=60,
                  block_delay=30,
                  unblock_delay=30,
-                 stop_words=['shop', 'store', 'free']):
+                 stop_words=['shop', 'store', 'free'],
+                 verbosity=True,
+                 ):
         super(Bot, self).__init__()
 
         self.total_liked = 0
@@ -146,6 +147,8 @@ class Bot(API):
         self.blacklist = []
         if blacklist:
             self.blacklist = read_list_from_file(blacklist)
+
+        self.verbosity = verbosity
 
         # comment file
         self.comments = []

--- a/instabot/bot/bot_filter.py
+++ b/instabot/bot/bot_filter.py
@@ -152,9 +152,8 @@ def check_user(self, user_id, filter_closed_acc=False, unfollowing=False):
 
     if self.verbosity:
         if self.verbosity:
-            print('\n USER_NAME: %s , FOLLOWER: %s , FOLLOWING: %s ' % (user_info[
-                                                                            "username"], user_info["follower_count"],
-                                                                        user_info["following_count"]))
+            print('\n USER_NAME: %s , FOLLOWER: %s , '
+                  'FOLLOWING: %s ' % (user_info["username"], user_info["follower_count"], user_info["following_count"]))
 
     if filter_closed_acc and "is_private" in user_info:
         if user_info["is_private"]:

--- a/instabot/bot/bot_filter.py
+++ b/instabot/bot/bot_filter.py
@@ -3,6 +3,7 @@
 """
 
 from . import delay
+from . import console_logger
 
 
 # Adding useless userd_ids to the skipped_list file: skipped.txt , so
@@ -13,12 +14,11 @@ def skippedlist_adder(self, user_id):
     skipped = self.read_list_from_file("skipped.txt")
     if user_id not in skipped:
         with open('skipped.txt', "a") as file:
-            if self.verbosity:
-                print('\n\033[93m Add user_id %s to skippedlist : skipped.txt ... \033[0m' % user_id)
+            console_logger.print(self.verbosity, '\n\033[93m Add user_id %s to skippedlist : skipped.txt ... \033[0m'
+                                 % user_id)
             # Append user_is to the end of skipped.txt
             file.write(str(user_id) + "\n")
-            if self.verbosity:
-                print('Done adding user_id to skipped.txt')
+            console_logger.print(self.verbosity, 'Done adding user_id to skipped.txt')
     return
 
 
@@ -113,114 +113,87 @@ def filter_users(self, user_id_list):
 
 def check_user(self, user_id, filter_closed_acc=False, unfollowing=False):
     if not self.filter_users and not unfollowing:
-        if self.verbosity:
-            print('\n\033[91m filter_users is False , Skipping \033[0m')  # Log to Console
+        console_logger.print(self.verbosity, '\n\033[91m filter_users is False , Skipping \033[0m')
         return True
 
     delay.small_delay(self)
     user_id = self.convert_to_user_id(user_id)
 
     if not user_id:
-        if self.verbosity:
-            print('\n\033[91m not user_id , Skipping \033[0m')  # Log to Console
+        console_logger.print(self.verbosity, '\n\033[91m not user_id , Skipping \033[0m')
         return False
     if self.whitelist and user_id in self.whitelist:
-        if self.verbosity:
-            print('\n\033[92m user_id in self.whitelist \033[0m')  # Log to Console
+        console_logger.print(self.verbosity, '\n\033[92m user_id in self.whitelist \033[0m')
         return True
     if self.blacklist and user_id in self.blacklist:
-        if self.verbosity:
-            print('\n\033[91m user_id in self.blacklist \033[0m')  # Log to Console
+        console_logger.print(self.verbosity, '\n\033[91m user_id in self.blacklist \033[0m')
         return False
 
     if not self.following:
-        # Log to Console
-        if self.verbosity:
-            print('\n\033[92m Own following list is empty , downloading ...\033[0m')
+        console_logger.print(self.verbosity, '\n\033[92m Own following list is empty , downloading ...\033[0m')
         self.following = self.get_user_following(self.user_id)
     if user_id in self.following:
         # Log to Console
-        if self.verbosity:
-            print('\n\033[91m Already following , Skipping \033[0m')
+        console_logger.print(self.verbosity, '\n\033[91m Already following , Skipping \033[0m')
         return False
 
     user_info = self.get_user_info(user_id)
     if not user_info:
-        if self.verbosity:
-            print('\n\033[91m not user_info , Skipping \033[0m')  # Log to Console
+        console_logger.print(self.verbosity, '\n\033[91m not user_info , Skipping \033[0m')
         return False
 
-    if self.verbosity:
-        if self.verbosity:
-            print('\n USER_NAME: %s , FOLLOWER: %s , '
-                  'FOLLOWING: %s ' % (user_info["username"], user_info["follower_count"], user_info["following_count"]))
+    console_logger.print(self.verbosity, '\n USER_NAME: %s , FOLLOWER: %s , '
+                                         'FOLLOWING: %s ' % (user_info["username"], user_info["follower_count"],
+                                                             user_info["following_count"]))
 
     if filter_closed_acc and "is_private" in user_info:
         if user_info["is_private"]:
-            # Log to Console
-            if self.verbosity:
-                print('\n info : \033[91m is PRIVATE , !!! \033[0m')
+            console_logger.print(self.verbosity, '\n info : \033[91m is PRIVATE , !!! \033[0m')
             return False
     if "is_business" in user_info:
         if user_info["is_business"]:
-            # Log to Console
-            if self.verbosity:
-                print('\n info : \033[91m is BUSINESS , Skipping \033[0m')
+            console_logger.print(self.verbosity, '\n info : \033[91m is BUSINESS , Skipping \033[0m')
             skippedlist_adder(self, user_id)  # Add user_id to skipped.txt
             return False
     if "is_verified" in user_info:
         if user_info["is_verified"]:
-            # Log to Console
-            if self.verbosity:
-                print('\n info : \033[91m is VERIFIED , Skipping \033[0m')
+            console_logger.print(self.verbosity, '\n info : \033[91m is VERIFIED , Skipping \033[0m')
             skippedlist_adder(self, user_id)  # Add user_id to skipped.txt
             return False
     if "follower_count" in user_info and "following_count" in user_info:
         if user_info["follower_count"] < self.min_followers_to_follow:
-            # Log to Console
-            if self.verbosity:
-                print(
-                    '\n\033[91m user_info["follower_count"] < self.min_followers_to_follow , Skipping \033[0m')
+            console_logger.print(self.verbosity, '\n\033[91m user_info["follower_count"] < self.min_followers_to_'
+                                                 'follow , Skipping \033[0m')
             skippedlist_adder(self, user_id)  # Add user_id to skipped.txt
             return False
         if user_info["follower_count"] > self.max_followers_to_follow:
-            # Log to Console
-            if self.verbosity:
-                print(
-                    '\n\033[91m user_info["follower_count"] > self.max_followers_to_follow , Skipping \033[0m')
+            console_logger.print(self.verbosity, '\n\033[91m user_info["follower_count"] > '
+                                                 'self.max_followers_to_follow , Skipping \033[0m')
+
             skippedlist_adder(self, user_id)  # Add user_id to skipped.txt
             return False
         if user_info["following_count"] < self.min_following_to_follow:
-            # Log to Console
-            if self.verbosity:
-                print(
-                    '\n\033[91m user_info["following_count"] < self.min_following_to_follow , Skipping \033[0m')
+            console_logger.print(self.verbosity, '\n\033[91m user_info["following_count"] < '
+                                                 'self.min_following_to_follow , Skipping \033[0m')
             skippedlist_adder(self, user_id)  # Add user_id to skipped.txt
             return False
         if user_info["following_count"] > self.max_following_to_follow:
-            # Log to Console
-            if self.verbosity:
-                print(
-                    '\n\033[91m user_info["following_count"] > self.max_following_to_follow , Skipping \033[0m')
+            console_logger.print(self.verbosity, '\n\033[91m user_info["following_count"] > '
+                                                 'self.max_following_to_follow , Skipping \033[0m')
             skippedlist_adder(self, user_id)  # Add user_id to skipped.txt
             return False
         try:
             if user_info["follower_count"] / user_info["following_count"] \
                     > self.max_followers_to_following_ratio:
-                # Log to Console
-                if self.verbosity:
-                    print(
-                        '\n\033[91m ["follower_count"] / ["following_count"] > self.max_followers_to_following_ratio , '
-                        'Skipping \033[0m')
+                console_logger.print(self.verbosity, '\n\033[91m ["follower_count"] / ["following_count"] > '
+                                                     'self.max_followers_to_following_ratio , Skipping \033[0m')
                 skippedlist_adder(self, user_id)  # Add user_id to skipped.txt
                 return False
             if user_info["following_count"] / user_info["follower_count"] \
                     > self.max_following_to_followers_ratio:
-                # Log to Console
-                if self.verbosity:
-                    print(
-                        '\n\033[91m ["following_count"] / ["follower_count"] > self.max_following_to_followers_ratio '
-                        ', Skipping \033[0m')
+
+                console_logger.print(self.verbosity, '\n\033[91m ["following_count"] / ["follower_count"] > '
+                                                     'self.max_following_to_followers_ratio , Skipping \033[0m')
                 skippedlist_adder(self, user_id)  # Add user_id to skipped.txt
                 return False
         except ZeroDivisionError:
@@ -229,18 +202,14 @@ def check_user(self, user_id, filter_closed_acc=False, unfollowing=False):
 
     if 'media_count' in user_info:
         if user_info["media_count"] < self.min_media_count_to_follow:
-            # Log to Console
-            if self.verbosity:
-                print(
-                    '\n\033[91m user_info["media_count"] < self.min_media_count_to_follow , BOT or InActive , '
-                    'Skipping \033[0m')
+            console_logger.print(self.verbosity, '\n\033[91m user_info["media_count"] < self.min_media_count_to_'
+                                                 'follow , BOT or InActive , Skipping \033[0m')
+
             skippedlist_adder(self, user_id)  # Add user_id to skipped.txt
             return False  # bot or inactive user
 
     if search_stop_words_in_user(self, user_info):
-        # Log to Console
-        if self.verbosity:
-            print('\n\033[91m search_stop_words_in_user , Skipping \033[0m')
+        console_logger.print(self.verbosity, '\n\033[91m search_stop_words_in_user , Skipping \033[0m')
         skippedlist_adder(self, user_id)  # Add user_id to skipped.txt
         return False
 
@@ -264,17 +233,13 @@ def check_not_bot(self, user_id):
 
     if "following_count" in user_info:
         if user_info["following_count"] > self.max_following_to_block:
-            # Log to Console
-            if self.verbosity:
-                print(
-                    '\n\033[91m user_info["following_count"] > self.max_following_to_block , Skipping \033[0m')
+            console_logger.print(self.verbosity, '\n\033[91m user_info["following_count"] > '
+                                                 'self.max_following_to_block , Skipping \033[0m')
             skippedlist_adder(self, user_id)  # Add user_id to skipped.txt
             return False  # massfollower
 
     if search_stop_words_in_user(self, user_info):
-        # Log to Console
-        if self.verbosity:
-            print('\n\033[91m search_stop_words_in_user , Skipping \033[0m')
+        console_logger.print(self.verbosity, '\n\033[91m search_stop_words_in_user , Skipping \033[0m')
         skippedlist_adder(self, user_id)  # Add user_id to skipped.txt
         return False
 

--- a/instabot/bot/bot_filter.py
+++ b/instabot/bot/bot_filter.py
@@ -13,10 +13,12 @@ def skippedlist_adder(self, user_id):
     skipped = self.read_list_from_file("skipped.txt")
     if user_id not in skipped:
         with open('skipped.txt', "a") as file:
-            print('\n\033[93m Add user_id %s to skippedlist : skipped.txt ... \033[0m' % user_id)
+            if self.verbosity:
+                print('\n\033[93m Add user_id %s to skippedlist : skipped.txt ... \033[0m' % user_id)
             # Append user_is to the end of skipped.txt
             file.write(str(user_id) + "\n")
-            print('Done adding user_id to skipped.txt')
+            if self.verbosity:
+                print('Done adding user_id to skipped.txt')
     return
 
 
@@ -83,6 +85,7 @@ def check_media(self, media_id):
     else:
         return False
 
+
 # filter users
 
 
@@ -110,94 +113,115 @@ def filter_users(self, user_id_list):
 
 def check_user(self, user_id, filter_closed_acc=False, unfollowing=False):
     if not self.filter_users and not unfollowing:
-        print('\n\033[91m filter_users is False , Skipping \033[0m')  # Log to Console
+        if self.verbosity:
+            print('\n\033[91m filter_users is False , Skipping \033[0m')  # Log to Console
         return True
 
     delay.small_delay(self)
     user_id = self.convert_to_user_id(user_id)
 
     if not user_id:
-        print('\n\033[91m not user_id , Skipping \033[0m')  # Log to Console
+        if self.verbosity:
+            print('\n\033[91m not user_id , Skipping \033[0m')  # Log to Console
         return False
     if self.whitelist and user_id in self.whitelist:
-        print('\n\033[92m user_id in self.whitelist \033[0m')  # Log to Console
+        if self.verbosity:
+            print('\n\033[92m user_id in self.whitelist \033[0m')  # Log to Console
         return True
     if self.blacklist and user_id in self.blacklist:
-        print('\n\033[91m user_id in self.blacklist \033[0m')  # Log to Console
+        if self.verbosity:
+            print('\n\033[91m user_id in self.blacklist \033[0m')  # Log to Console
         return False
 
     if not self.following:
         # Log to Console
-        print(
-            '\n\033[92m My own following list is empty , downloading ...\033[0m')
+        if self.verbosity:
+            print('\n\033[92m Own following list is empty , downloading ...\033[0m')
         self.following = self.get_user_following(self.user_id)
     if user_id in self.following:
         # Log to Console
-        print('\n\033[91m Already following , Skipping \033[0m')
+        if self.verbosity:
+            print('\n\033[91m Already following , Skipping \033[0m')
         return False
 
     user_info = self.get_user_info(user_id)
     if not user_info:
-        print('\n\033[91m not user_info , Skipping \033[0m')  # Log to Console
+        if self.verbosity:
+            print('\n\033[91m not user_info , Skipping \033[0m')  # Log to Console
         return False
 
-    print('\n USER_NAME: %s , FOLLOWER: %s , FOLLOWING: %s ' % (user_info[
-          "username"], user_info["follower_count"], user_info["following_count"]))  # Log to Console
+    if self.verbosity:
+        if self.verbosity:
+            print('\n USER_NAME: %s , FOLLOWER: %s , FOLLOWING: %s ' % (user_info[
+                                                                            "username"], user_info["follower_count"],
+                                                                        user_info["following_count"]))
+
     if filter_closed_acc and "is_private" in user_info:
         if user_info["is_private"]:
             # Log to Console
-            print('\n info : \033[91m is PRIVATE , !!! \033[0m')
+            if self.verbosity:
+                print('\n info : \033[91m is PRIVATE , !!! \033[0m')
             return False
     if "is_business" in user_info:
         if user_info["is_business"]:
             # Log to Console
-            print('\n info : \033[91m is BUSINESS , Skipping \033[0m')
+            if self.verbosity:
+                print('\n info : \033[91m is BUSINESS , Skipping \033[0m')
             skippedlist_adder(self, user_id)  # Add user_id to skipped.txt
             return False
     if "is_verified" in user_info:
         if user_info["is_verified"]:
             # Log to Console
-            print('\n info : \033[91m is VERIFIED , Skipping \033[0m')
+            if self.verbosity:
+                print('\n info : \033[91m is VERIFIED , Skipping \033[0m')
             skippedlist_adder(self, user_id)  # Add user_id to skipped.txt
             return False
     if "follower_count" in user_info and "following_count" in user_info:
         if user_info["follower_count"] < self.min_followers_to_follow:
             # Log to Console
-            print(
-                '\n\033[91m user_info["follower_count"] < self.min_followers_to_follow , Skipping \033[0m')
+            if self.verbosity:
+                print(
+                    '\n\033[91m user_info["follower_count"] < self.min_followers_to_follow , Skipping \033[0m')
             skippedlist_adder(self, user_id)  # Add user_id to skipped.txt
             return False
         if user_info["follower_count"] > self.max_followers_to_follow:
             # Log to Console
-            print(
-                '\n\033[91m user_info["follower_count"] > self.max_followers_to_follow , Skipping \033[0m')
+            if self.verbosity:
+                print(
+                    '\n\033[91m user_info["follower_count"] > self.max_followers_to_follow , Skipping \033[0m')
             skippedlist_adder(self, user_id)  # Add user_id to skipped.txt
             return False
         if user_info["following_count"] < self.min_following_to_follow:
             # Log to Console
-            print(
-                '\n\033[91m user_info["following_count"] < self.min_following_to_follow , Skipping \033[0m')
+            if self.verbosity:
+                print(
+                    '\n\033[91m user_info["following_count"] < self.min_following_to_follow , Skipping \033[0m')
             skippedlist_adder(self, user_id)  # Add user_id to skipped.txt
             return False
         if user_info["following_count"] > self.max_following_to_follow:
             # Log to Console
-            print(
-                '\n\033[91m user_info["following_count"] > self.max_following_to_follow , Skipping \033[0m')
+            if self.verbosity:
+                print(
+                    '\n\033[91m user_info["following_count"] > self.max_following_to_follow , Skipping \033[0m')
             skippedlist_adder(self, user_id)  # Add user_id to skipped.txt
             return False
         try:
             if user_info["follower_count"] / user_info["following_count"] \
                     > self.max_followers_to_following_ratio:
                 # Log to Console
-                print(
-                    '\n\033[91m ["follower_count"] / ["following_count"] > self.max_followers_to_following_ratio , Skipping \033[0m')
+                if self.verbosity:
+                    print(
+                        '\n\033[91m ["follower_count"] / ["following_count"] > self.max_followers_to_following_ratio , '
+                        'Skipping \033[0m')
                 skippedlist_adder(self, user_id)  # Add user_id to skipped.txt
                 return False
             if user_info["following_count"] / user_info["follower_count"] \
                     > self.max_following_to_followers_ratio:
                 # Log to Console
-                print(
-                    '\n\033[91m ["following_count"] / ["follower_count"] > self.max_following_to_followers_ratio , Skipping \033[0m')
+                if self.verbosity:
+                    print(
+                        '\n\033[91m ["following_count"] / ["follower_count"] > self.max_following_to_followers_ratio '
+                        ', Skipping \033[0m')
                 skippedlist_adder(self, user_id)  # Add user_id to skipped.txt
                 return False
         except ZeroDivisionError:
@@ -207,14 +231,17 @@ def check_user(self, user_id, filter_closed_acc=False, unfollowing=False):
     if 'media_count' in user_info:
         if user_info["media_count"] < self.min_media_count_to_follow:
             # Log to Console
-            print(
-                '\n\033[91m user_info["media_count"] < self.min_media_count_to_follow , BOT or InActive , Skipping \033[0m')
+            if self.verbosity:
+                print(
+                    '\n\033[91m user_info["media_count"] < self.min_media_count_to_follow , BOT or InActive , '
+                    'Skipping \033[0m')
             skippedlist_adder(self, user_id)  # Add user_id to skipped.txt
             return False  # bot or inactive user
 
     if search_stop_words_in_user(self, user_info):
         # Log to Console
-        print('\n\033[91m search_stop_words_in_user , Skipping \033[0m')
+        if self.verbosity:
+            print('\n\033[91m search_stop_words_in_user , Skipping \033[0m')
         skippedlist_adder(self, user_id)  # Add user_id to skipped.txt
         return False
 
@@ -239,14 +266,16 @@ def check_not_bot(self, user_id):
     if "following_count" in user_info:
         if user_info["following_count"] > self.max_following_to_block:
             # Log to Console
-            print(
-                '\n\033[91m user_info["following_count"] > self.max_following_to_block , Skipping \033[0m')
+            if self.verbosity:
+                print(
+                    '\n\033[91m user_info["following_count"] > self.max_following_to_block , Skipping \033[0m')
             skippedlist_adder(self, user_id)  # Add user_id to skipped.txt
             return False  # massfollower
 
     if search_stop_words_in_user(self, user_info):
         # Log to Console
-        print('\n\033[91m search_stop_words_in_user , Skipping \033[0m')
+        if self.verbosity:
+            print('\n\033[91m search_stop_words_in_user , Skipping \033[0m')
         skippedlist_adder(self, user_id)  # Add user_id to skipped.txt
         return False
 

--- a/instabot/bot/bot_follow.py
+++ b/instabot/bot/bot_follow.py
@@ -2,6 +2,7 @@ from tqdm import tqdm
 
 from . import limits
 from . import delay
+from . import console_logger
 
 
 def follow(self, user_id):
@@ -12,12 +13,11 @@ def follow(self, user_id):
     if limits.check_if_bot_can_follow(self):
         delay.follow_delay(self)
         if super(self.__class__, self).follow(user_id):
-            if self.verbosity:
-                print('\n\033[92m ===> FOLLOWED <==== user_id: %s \033[0m' % (user_id))  # Log to console
+            console_logger.print(self.verbosity, '\n\033[92m ===> FOLLOWED <==== user_id: %s \033[0m')
             self.total_followed += 1
             # Log to console
-            if self.verbosity:
-                print('\n\033[92m Writing user_id to file : followed.txt ... \033[0m')
+            console_logger.print(self.verbosity, '\n\033[92m Writing user_id to file : followed.txt ... \033[0m')
+
             with open('followed.txt', 'a') as file:  # Appending user_id to the followed.txt
                 # Appending user_id to the followed.txt
                 file.write(str(user_id) + "\n")

--- a/instabot/bot/bot_follow.py
+++ b/instabot/bot/bot_follow.py
@@ -12,12 +12,12 @@ def follow(self, user_id):
     if limits.check_if_bot_can_follow(self):
         delay.follow_delay(self)
         if super(self.__class__, self).follow(user_id):
-            print('\n\033[92m ===> FOLLOWED <==== user_id: %s \033[0m' % (
-                user_id))  # Log to console
+            if self.verbosity:
+                print('\n\033[92m ===> FOLLOWED <==== user_id: %s \033[0m' % (user_id))  # Log to console
             self.total_followed += 1
             # Log to console
-            print(
-                '\n\033[92m Writing user_id to file : followed.txt ... \033[0m')
+            if self.verbosity:
+                print('\n\033[92m Writing user_id to file : followed.txt ... \033[0m')
             with open('followed.txt', 'a') as file:  # Appending user_id to the followed.txt
                 # Appending user_id to the followed.txt
                 file.write(str(user_id) + "\n")

--- a/instabot/bot/bot_unfollow.py
+++ b/instabot/bot/bot_unfollow.py
@@ -2,22 +2,22 @@ from tqdm import tqdm
 
 from . import limits
 from . import delay
+from . import console_logger
 
 
 def unfollow(self, user_id):
     user_id = self.convert_to_user_id(user_id)
     user_info = self.get_user_info(user_id)
-    if self.verbosity:
-        print('\n===> Going to UN-Follow user_id: %s , user_name: %s' % (user_id, user_info["username"]))
+    console_logger.print(self.verbosity, '\n===> Going to UN-Follow user_id: %s , user_name: %s'
+                         % (user_id, user_info["username"]))
 
     if self.check_user(user_id, unfollowing=True):
         return True  # whitelisted user
     if limits.check_if_bot_can_unfollow(self):
         delay.unfollow_delay(self)
         if super(self.__class__, self).unfollow(user_id):
-            if self.verbosity:
-                print('\033[93m===> UN-FOLLOWED , user_id: %s , user_name: %s \033[0m\n' % (
-                    user_id, user_info["username"]))
+            console_logger.print(self.verbosity, '\033[93m===> UN-FOLLOWED , user_id: %s , user_name: %s \033[0m\n' % (
+                user_id, user_info["username"]))
             self.total_unfollowed += 1
             return True
     else:
@@ -46,15 +46,14 @@ def unfollow_users(self, user_ids):
 def unfollow_non_followers(self, n_to_unfollows=None):
     self.logger.info("Unfollowing non-followers")
     self.update_unfollow_file()
-    if self.verbosity:
-        print("\n\033[91m ===> Start Unfollowing Non_Followers List <===\033[0m")
+    console_logger.print(self.verbosity, "\n\033[91m ===> Start Unfollowing Non_Followers List <===\033[0m")
+
     unfollow_file = "unfollow.txt"
     with open(unfollow_file) as unfollow_data:
         new_unfollow_list = list(line.strip() for line in unfollow_data)
     for user in tqdm(new_unfollow_list[:n_to_unfollows]):  # select only first n_to_unfollows users to unfollow
         self.unfollow(user)
-    if self.verbosity:
-        print("\n\033[91m ===> Unfollow Non_followers , Task Done <===\033[0m")
+    console_logger.print(self.verbosity, "\n\033[91m ===> Unfollow Non_followers , Task Done <===\033[0m")
 
 
 def unfollow_everyone(self):
@@ -64,8 +63,7 @@ def unfollow_everyone(self):
 
 def update_unfollow_file(self):  # Update unfollow.txt
     self.logger.info("Updating unfollow.txt ...")
-    if self.verbosity:
-        print("\n\033[92m Calculating Non Followers List  \033[0m")
+    console_logger.print(self.verbosity, "\n\033[92m Calculating Non Followers List  \033[0m")
 
     followings = self.get_user_following(self.user_id)  # getting following
     followers = self.get_user_followers(self.user_id)  # getting followers
@@ -83,9 +81,8 @@ def update_unfollow_file(self):  # Update unfollow.txt
     new_unfollow_list += [x for x in unfollow_file if x in unfollow_list]
     new_unfollow_list += [x for x in unfollow_list if x not in unfollow_file]
 
-    if self.verbosity:
-        print("\n Writing to unfollow.txt")
+    console_logger.print(self.verbosity, "\n Writing to unfollow.txt")
     with open('unfollow.txt', 'w') as out:
         for line in new_unfollow_list:
             out.write(str(line) + "\n")
-    print("\n Updating unfollow.txt , Task Done")
+    console_logger.print(self.verbosity, "\n Updating unfollow.txt , Task Done")

--- a/instabot/bot/bot_unfollow.py
+++ b/instabot/bot/bot_unfollow.py
@@ -17,7 +17,7 @@ def unfollow(self, user_id):
         if super(self.__class__, self).unfollow(user_id):
             if self.verbosity:
                 print('\033[93m===> UN-FOLLOWED , user_id: %s , user_name: %s \033[0m\n' % (
-                user_id, user_info["username"]))
+                    user_id, user_info["username"]))
             self.total_unfollowed += 1
             return True
     else:

--- a/instabot/bot/bot_unfollow.py
+++ b/instabot/bot/bot_unfollow.py
@@ -7,15 +7,17 @@ from . import delay
 def unfollow(self, user_id):
     user_id = self.convert_to_user_id(user_id)
     user_info = self.get_user_info(user_id)
-    print('\n===> Going to UN-Follow user_id: %s , user_name: %s' %
-          (user_id, user_info["username"]))
+    if self.verbosity:
+        print('\n===> Going to UN-Follow user_id: %s , user_name: %s' % (user_id, user_info["username"]))
+
     if self.check_user(user_id, unfollowing=True):
         return True  # whitelisted user
     if limits.check_if_bot_can_unfollow(self):
         delay.unfollow_delay(self)
         if super(self.__class__, self).unfollow(user_id):
-            print('\033[93m===> UN-FOLLOWED , user_id: %s , user_name: %s \033[0m\n' %
-                  (user_id, user_info["username"]))
+            if self.verbosity:
+                print('\033[93m===> UN-FOLLOWED , user_id: %s , user_name: %s \033[0m\n' % (
+                user_id, user_info["username"]))
             self.total_unfollowed += 1
             return True
     else:
@@ -44,14 +46,15 @@ def unfollow_users(self, user_ids):
 def unfollow_non_followers(self, n_to_unfollows=None):
     self.logger.info("Unfollowing non-followers")
     self.update_unfollow_file()
-    print("\n\033[91m ===> Start Unfollowing Non_Followers List <===\033[0m")
+    if self.verbosity:
+        print("\n\033[91m ===> Start Unfollowing Non_Followers List <===\033[0m")
     unfollow_file = "unfollow.txt"
     with open(unfollow_file) as unfollow_data:
         new_unfollow_list = list(line.strip() for line in unfollow_data)
     for user in tqdm(new_unfollow_list[:n_to_unfollows]):  # select only first n_to_unfollows users to unfollow
         self.unfollow(user)
-    print(
-        "\n\033[91m ===> Unfollow Non_followers , Task Done <===\033[0m")
+    if self.verbosity:
+        print("\n\033[91m ===> Unfollow Non_followers , Task Done <===\033[0m")
 
 
 def unfollow_everyone(self):
@@ -61,7 +64,9 @@ def unfollow_everyone(self):
 
 def update_unfollow_file(self):  # Update unfollow.txt
     self.logger.info("Updating unfollow.txt ...")
-    print("\n\033[92m Calculating Non Followers List  \033[0m")
+    if self.verbosity:
+        print("\n\033[92m Calculating Non Followers List  \033[0m")
+
     followings = self.get_user_following(self.user_id)  # getting following
     followers = self.get_user_followers(self.user_id)  # getting followers
     friends_file = self.read_list_from_file(
@@ -77,7 +82,9 @@ def update_unfollow_file(self):  # Update unfollow.txt
     new_unfollow_list = []
     new_unfollow_list += [x for x in unfollow_file if x in unfollow_list]
     new_unfollow_list += [x for x in unfollow_list if x not in unfollow_file]
-    print("\n Writing to unfollow.txt")
+
+    if self.verbosity:
+        print("\n Writing to unfollow.txt")
     with open('unfollow.txt', 'w') as out:
         for line in new_unfollow_list:
             out.write(str(line) + "\n")

--- a/instabot/bot/console_logger.py
+++ b/instabot/bot/console_logger.py
@@ -1,0 +1,5 @@
+class ConsoleLogger:
+    @staticmethod
+    def print(verbosity, text):
+        if verbosity:
+            print(text)


### PR DESCRIPTION
With this branch users of this package can set `verbosity `to `False ` when initiaiting the `Bot` (default is `True`). When done, much less info like "Skipping" or "Writing user id to followed.txt" will be printed to the console.

The output will look _cleaner_ for those who prefer it.