### PR TITLE
Whitelist: Show non-existing usernames

### DIFF
--- a/instabot/bot/bot.py
+++ b/instabot/bot/bot.py
@@ -182,10 +182,22 @@ class Bot(API):
             self.total_liked, self.total_unliked, self.total_followed, self.total_unfollowed, self.total_commented, self.total_blocked, self.total_unblocked, self.total_requests, self.start_time, self.total_archived, self.total_unarchived = storage
         if not self.whitelist:
             self.whitelist = check_whitelists(self)
-        self.whitelist = list(
-            filter(None, map(self.convert_to_user_id, self.whitelist)))
+        self.whitelist = self.convert_whitelist(self.whitelist)
         self.blacklist = list(
             filter(None, map(self.convert_to_user_id, self.blacklist)))
+
+    def convert_whitelist(self, usernames):
+        """
+        Will convert every username in the whitelist to the user id.
+        """
+        ret = []
+        for u in usernames:
+            uid = self.convert_to_user_id(u)
+            if uid and uid not in ret:
+                ret.append(uid)
+            else:
+                print("WARNING: Whitelisted user '%s' not found" % u)
+        return ret
 
     def print_counters(self):
         if self.total_liked:


### PR DESCRIPTION
Currently, when checking the whitelist (getting IDs from screen names) the process just prints `404` when a username is not found. Problem: Which one? Especially when the whitelist is big.

Pull request: A method which does the same thing, but prints the usernames which could not be resolved to an user id. 

This helps fixing the whitelist **a lot**.