### PR TITLE
Limit follower load on like_follower

### DIFF
--- a/instabot/bot/bot.py
+++ b/instabot/bot/bot.py
@@ -337,8 +337,8 @@ class Bot(API):
     def like_users(self, user_ids, nlikes=None, filtration=True):
         return like_users(self, user_ids, nlikes, filtration)
 
-    def like_followers(self, user_id, nlikes=None):
-        return like_followers(self, user_id, nlikes)
+    def like_followers(self, user_id, nlikes=None, nfollows=None):
+        return like_followers(self, user_id, nlikes, nfollows)
 
     def like_following(self, user_id, nlikes=None):
         return like_following(self, user_id, nlikes)

--- a/instabot/bot/bot_like.py
+++ b/instabot/bot/bot_like.py
@@ -70,7 +70,7 @@ def like_geotag(self, geotag, amount=None):
     pass
 
 
-def like_followers(self, user_id, nlikes=None):
+def like_followers(self, user_id, nlikes=None, nfollows=None):
     self.logger.info("Like followers of: %s." % user_id)
     if not limits.check_if_bot_can_like(self):
         self.logger.info("Out of likes for today.")
@@ -78,11 +78,11 @@ def like_followers(self, user_id, nlikes=None):
     if not user_id:
         self.logger.info("User not found.")
         return
-    follower_ids = self.get_user_followers(user_id)
+    follower_ids = self.get_user_followers(user_id, nfollows)
     if not follower_ids:
         self.logger.info("%s not found / closed / has no followers." % user_id)
     else:
-        self.like_users(follower_ids, nlikes)
+        self.like_users(follower_ids[:nfollows], nlikes)
 
 
 def like_following(self, user_id, nlikes=None):


### PR DESCRIPTION
Added option nfollows on like_followers.
Added the possibility to limit the number of loaded followers from user_id that have a very high number of follower.

I Think this option are usefull for many users