### PR TITLE
Ensure that empty strings are not read from a file, closes #496

### DIFF
--- a/instabot/bot/bot_support.py
+++ b/instabot/bot/bot_support.py
@@ -32,8 +32,8 @@ def read_list_from_file(file_path, quiet=False):
             content = file_descriptor.readlines()
             if sys.version_info[0] < 3:
                 content = [str(item.encode('utf8')) for item in content]
-            content = [item.strip() for item in content if len(item) > 0]
-            return content
+            content = [item.strip() for item in content]
+            return [i for i in content if i]
     except Exception as exception:
         print(str(exception))
         return []

--- a/instabot/utils.py
+++ b/instabot/utils.py
@@ -14,7 +14,8 @@ class file(object):
     @property
     def list(self):
         with open(self.fname, 'r') as f:
-            return [x.strip('\n') for x in f.readlines()]
+            lines = [x.strip('\n') for x in f.readlines()]
+            return [x for x in lines if x]
 
     @property
     def set(self):


### PR DESCRIPTION
Previously an empty line with a space would give rise to errors, this PR fixes that.