### PR TITLE
Update the followers and following cache to not overflow the API

### DIFF
--- a/instabot/bot/bot.py
+++ b/instabot/bot/bot.py
@@ -191,16 +191,22 @@ class Bot(object):
 
     @property
     def following(self):
-        if self._following is None:
+        now = time.time()
+        last = self.last.get('updated_following', now)
+        if self._following is None or now - last > 7200:
             self.console_print('`bot.following` is empty, will download.', 'green')
             self._following = self.get_user_following(self.user_id)
+            self.last['updated_following'] = now
         return self._following
 
     @property
     def followers(self):
-        if self._followers is None:
+        now = time.time()
+        last = self.last.get('updated_followers', now)
+        if self._followers is None or now - last > 7200:
             self.console_print('`bot.followers` is empty, will download.', 'green')
             self._followers = self.get_user_followers(self.user_id)
+            self.last['updated_followers'] = now
         return self._followers
 
     def version(self):

--- a/instabot/bot/bot_follow.py
+++ b/instabot/bot/bot_follow.py
@@ -16,7 +16,8 @@ def follow(self, user_id):
             self.console_print(msg, 'green')
             self.total['follows'] += 1
             self.followed_file.append(user_id)
-            self._following = None  # Invalidate cache
+            if user_id not in self._following:
+                self._following.append(user_id)
             return True
     else:
         self.logger.info("Out of follows for today.")

--- a/instabot/bot/bot_unfollow.py
+++ b/instabot/bot/bot_unfollow.py
@@ -16,7 +16,8 @@ def unfollow(self, user_id):
             self.console_print(msg.format(user_id, username), 'yellow')
             self.unfollowed_file.append(user_id)
             self.total['unfollows'] += 1
-            self._following = None  # Invalidate cache
+            if user_id in self._following:
+                self._following.remove(user_id)
             return True
     else:
         self.logger.info("Out of unfollows for today.")


### PR DESCRIPTION
Using a follow/unfollow bot will redownload the followers and followings many times. This is an easy fix.

The cache is updated every 2 hours in case the list gets out of sync (for an unknown reason.)