### PR TITLE
Implement previously followed user check in bot.follow()

### DIFF
--- a/instabot/bot/bot.py
+++ b/instabot/bot/bot.py
@@ -114,6 +114,7 @@ class Bot(object):
         self.filter_users = filter_users
         self.filter_business_accounts = filter_business_accounts
         self.filter_verified_accounts = filter_verified_accounts
+        self.filter_previously_followed = filter_previously_followed
 
         self.max_per_day = {'likes': max_likes_per_day,
                             'unlikes': max_unlikes_per_day,

--- a/instabot/bot/bot.py
+++ b/instabot/bot/bot.py
@@ -62,6 +62,7 @@ class Bot(object):
                  max_likes_to_like=100,
                  max_messages_per_day=300,
                  filter_users=True,
+                 filter_previously_followed=False,
                  filter_business_accounts=True,
                  filter_verified_accounts=True,
                  max_followers_to_follow=2000,

--- a/instabot/bot/bot_filter.py
+++ b/instabot/bot/bot_filter.py
@@ -129,7 +129,7 @@ def check_user(self, user_id, filter_closed_acc=False, unfollowing=False):
     followed = self.followed_file
 
     if not unfollowing:
-        if self.filter_previously_followed and used_id in followed.list:
+        if self.filter_previously_followed and user_id in followed.list:
             self.console_print('info: account previously followed, skipping!', 'red')
             return False
     if filter_closed_acc and "is_private" in user_info:

--- a/instabot/bot/bot_filter.py
+++ b/instabot/bot/bot_filter.py
@@ -126,7 +126,12 @@ def check_user(self, user_id, filter_closed_acc=False, unfollowing=False):
     ))
 
     skipped = self.skipped_file
+    followed = self.followed_file
 
+    if not unfollowing:
+        if self.filter_previously_followed and used_id in followed.list:
+            self.console_print('info: account previously followed, skipping!', 'red')
+            return False
     if filter_closed_acc and "is_private" in user_info:
         if user_info["is_private"]:
             self.console_print('info: account is PRIVATE, skipping! ', 'red')

--- a/instabot/bot/bot_follow.py
+++ b/instabot/bot/bot_follow.py
@@ -9,6 +9,11 @@ def follow(self, user_id):
     self.console_print(msg)
     if not self.check_user(user_id):
         return True
+    # Check if we hadn't previously followed the user
+    followed = self.followed_file
+    if user_id in followed:
+        self.logger.info("User previously followed, skipping.")
+        return True
     if not self.reached_limit('follows'):
         self.delay('follow')
         if self.api.follow(user_id):

--- a/instabot/bot/bot_follow.py
+++ b/instabot/bot/bot_follow.py
@@ -9,11 +9,6 @@ def follow(self, user_id):
     self.console_print(msg)
     if not self.check_user(user_id):
         return True
-    # Check if we hadn't previously followed the user
-    followed = self.followed_file
-    if user_id in followed.set:
-        self.logger.info("User previously followed, skipping.")
-        return True
     if not self.reached_limit('follows'):
         self.delay('follow')
         if self.api.follow(user_id):
@@ -36,12 +31,11 @@ def follow_users(self, user_ids):
         return
     msg = "Going to follow {} users.".format(len(user_ids))
     self.logger.info(msg)
-    followed = self.followed_file
     skipped = self.skipped_file
     self.console_print(msg, 'green')
 
-    # Remove skipped and followed list from user_ids
-    user_ids = list(set(user_ids) - followed.set - skipped.set)
+    # Remove skipped list from user_ids
+    user_ids = list(set(user_ids) - skipped.set)
     msg = 'After filtering `{}` and `{}`, {} user_ids left to follow.'
     msg = msg.format(followed.fname, skipped.fname, len(user_ids))
     self.console_print(msg, 'green')

--- a/instabot/bot/bot_follow.py
+++ b/instabot/bot/bot_follow.py
@@ -11,7 +11,7 @@ def follow(self, user_id):
         return True
     # Check if we hadn't previously followed the user
     followed = self.followed_file
-    if user_id in followed:
+    if user_id in followed.set:
         self.logger.info("User previously followed, skipping.")
         return True
     if not self.reached_limit('follows'):

--- a/instabot/bot/bot_follow.py
+++ b/instabot/bot/bot_follow.py
@@ -61,7 +61,7 @@ def follow_users(self, user_ids):
                     broken_items += user_ids[i:]
                     break
 
-    self.logger.info("DONE: Followed {} users in total.".format(self.total['follows']))
+    self.logger.info("DONE: Now following {} users in total.".format(self.total['follows']))
     return broken_items
 
 

--- a/instabot/bot/bot_follow.py
+++ b/instabot/bot/bot_follow.py
@@ -36,8 +36,8 @@ def follow_users(self, user_ids):
 
     # Remove skipped list from user_ids
     user_ids = list(set(user_ids) - skipped.set)
-    msg = 'After filtering `{}` and `{}`, {} user_ids left to follow.'
-    msg = msg.format(followed.fname, skipped.fname, len(user_ids))
+    msg = 'After filtering `{}`, {} user_ids left to follow.'
+    msg = msg.format(skipped.fname, len(user_ids))
     self.console_print(msg, 'green')
     for user_id in tqdm(user_ids, desc='Processed users'):
         if not self.follow(user_id):


### PR DESCRIPTION
I noticed that when using the bot.follow() function, the followed.txt file is ignored, and users are followed regardless of wheter they were previously followed or not. Since i noticed that the file is checked in the bot.follow_users() function, i thought that the same behavior would be desirable for the former function as well. I'm fairly new to the project though, so let me know if i'm missing some reasons not to implement this behavior or mistakes i have made when implementing the feature!