### PR TITLE
print more info when cookie is not found

### DIFF
--- a/instabot/api/api.py
+++ b/instabot/api/api.py
@@ -70,7 +70,7 @@ class API(object):
                 self.set_proxy()  # Only happens if `self.proxy`
                 self.logger.info("Logged-in successfully as '{}' using the cookie!".format(self.username))
                 return True
-            except Exception as e:
+            except Exception:
                 print("The cookie is not found, but don't worry `instabot`"
                       " will create it for you using your login details.")
 

--- a/instabot/api/api.py
+++ b/instabot/api/api.py
@@ -71,7 +71,8 @@ class API(object):
                 self.logger.info("Logged-in successfully as '{}' using the cookie!".format(self.username))
                 return True
             except Exception as e:
-                print(str(e))
+                print("The cookie is not found, but don't worry `instabot`"
+                      " will create it for you using your login details.")
 
         if not cookie_is_loaded and (not self.is_logged_in or force):
             self.session = requests.Session()


### PR DESCRIPTION
A lot of people are confused about the error `cookie.txt` not found.

This should help.