### PR TITLE
Allow for media with no captions

### DIFF
--- a/instabot/bot/bot_photo.py
+++ b/instabot/bot/bot_photo.py
@@ -19,7 +19,7 @@ def download_photo(self, media_id, folder='photos', filename=None, save_descript
         os.makedirs(folder)
     if save_description:
         media = self.get_media_info(media_id)[0]
-        caption = media['caption']['text'] if media['caption'] else u''
+        caption = media['caption']['text'] if media['caption'] else ''
         username = media['user']['username']
         fname = os.path.join(folder, '{}_{}.txt'.format(username, media_id))
         with open(fname, encoding='utf8', mode='w') as f:

--- a/instabot/bot/bot_photo.py
+++ b/instabot/bot/bot_photo.py
@@ -19,7 +19,7 @@ def download_photo(self, media_id, folder='photos', filename=None, save_descript
         os.makedirs(folder)
     if save_description:
         media = self.get_media_info(media_id)[0]
-        caption = media['caption']['text']
+        caption = media['caption']['text'] if media['caption'] else u''
         username = media['user']['username']
         fname = os.path.join(folder, '{}_{}.txt'.format(username, media_id))
         with open(fname, encoding='utf8', mode='w') as f:


### PR DESCRIPTION
If the media has no caption, then `media['caption']` will be `None`, which previously caused an error.

This change will save an empty file if there is no caption; let me know if instead you'd rather not create a file at all.