### PR TITLE
Update bot_follow.py to make bot not follow unfollowed and already followed

### DIFF
--- a/instabot/bot/bot_follow.py
+++ b/instabot/bot/bot_follow.py
@@ -32,11 +32,13 @@ def follow_users(self, user_ids):
     msg = "Going to follow {} users.".format(len(user_ids))
     self.logger.info(msg)
     skipped = self.skipped_file
+    followed = self.followed_file
+    unfollowed = self.unfollowed_file
     self.console_print(msg, 'green')
 
-    # Remove skipped list from user_ids
-    user_ids = list(set(user_ids) - skipped.set)
-    msg = 'After filtering `{}`, {} user_ids left to follow.'
+    # Remove skipped and already followed and unfollowed list from user_ids
+    user_ids = list(set(user_ids) - skipped.set - followed.set - unfollowed.set)
+    msg = 'After filtering followed, unfollowed and `{}`, {} user_ids left to follow.'
     msg = msg.format(skipped.fname, len(user_ids))
     self.console_print(msg, 'green')
     for user_id in tqdm(user_ids, desc='Processed users'):


### PR DESCRIPTION
Using the ultimate script the bot was not skipping users already followed and unfollowed. With this changes I'm trying to avoid multiple following of same users.

This is my first pull request. Let me know if I made something wrong! ;)