### PR TITLE
adding base path support for local files.

### DIFF
--- a/instabot/api/api.py
+++ b/instabot/api/api.py
@@ -27,11 +27,12 @@ PY2 = sys.version_info[0] == 2
 
 
 class API(object):
-    def __init__(self, device=None):
+    def __init__(self, device=None, base_path=''):
         # Setup device and user_agent
         device = device or devices.DEFAULT_DEVICE
         self.device_settings = devices.DEVICES[device]
         self.user_agent = config.USER_AGENT_BASE.format(**self.device_settings)
+        self.base_path = base_path
 
         self.is_logged_in = False
         self.last_response = None
@@ -40,7 +41,8 @@ class API(object):
         # Setup logging
         self.logger = logging.getLogger('[instabot_{}]'.format(id(self)))
 
-        fh = logging.FileHandler(filename='instabot.log')
+        log_filename = os.path.join(base_path, 'instabot.log')
+        fh = logging.FileHandler(filename=log_filename)
         fh.setLevel(logging.INFO)
         fh.setFormatter(logging.Formatter('%(asctime)s %(message)s'))
 
@@ -71,6 +73,7 @@ class API(object):
 
         if not cookie_fname:
             cookie_fname = "{username}_cookie.txt".format(username=username)
+            cookie_fname = os.path.join(self.base_path, cookie_fname)
 
         cookie_is_loaded = False
         if use_cookie:

--- a/instabot/bot/bot.py
+++ b/instabot/bot/bot.py
@@ -1,3 +1,4 @@
+import os
 import atexit
 import datetime
 import random
@@ -55,6 +56,7 @@ class Bot(object):
                  unfollowed_file='unfollowed.txt',
                  skipped_file='skipped.txt',
                  friends_file='friends.txt',
+                 base_path='',
                  proxy=None,
                  max_likes_per_day=1000,
                  max_unlikes_per_day=1000,
@@ -94,7 +96,8 @@ class Bot(object):
                  verbosity=True,
                  device=None
                  ):
-        self.api = API(device=device)
+        self.api = API(device=device, base_path=base_path)
+        self.base_path = base_path
 
         self.total = {'likes': 0,
                       'unlikes': 0,
@@ -168,6 +171,15 @@ class Bot(object):
         self._followers = None
         self._user_infos = {}  # User info cache
         self._usernames = {}  # `username` to `user_id` mapping
+
+        # Adjust file paths
+        followed_file = os.path.join(base_path, followed_file)
+        unfollowed_file = os.path.join(base_path, unfollowed_file)
+        skipped_file = os.path.join(base_path, skipped_file)
+        friends_file = os.path.join(base_path, friends_file)
+        comments_file = os.path.join(base_path, comments_file)
+        blacklist_file = os.path.join(base_path, blacklist_file)
+        whitelist_file = os.path.join(base_path, whitelist_file)
 
         # Database files
         self.followed_file = utils.file(followed_file)

--- a/instabot/bot/bot_checkpoint.py
+++ b/instabot/bot/bot_checkpoint.py
@@ -43,6 +43,7 @@ class Checkpoint(object):
 def save_checkpoint(self):
     checkpoint = Checkpoint(self)
     fname = CHECKPOINT_PATH.format(fname=self.api.username)
+    fname = os.path.join(self.base_path, fname)
     with open(fname, 'wb') as f:
         pickle.dump(checkpoint, f, -1)
     return True
@@ -51,6 +52,7 @@ def save_checkpoint(self):
 def load_checkpoint(self):
     try:
         fname = CHECKPOINT_PATH.format(fname=self.api.username)
+        fname = os.path.join(self.base_path, fname)
         with open(fname, 'rb') as f:
             checkpoint = pickle.load(f)
         if isinstance(checkpoint, Checkpoint):


### PR DESCRIPTION
Hello, it was hard to manage multiple bots in my automation tool due to filename collisions, so I added a base_path feature, so everyone can set a base_path instead of adjusting all the file names when instantiating.