### PR TITLE
do not always resize the photo on upload

### DIFF
--- a/instabot/api/api_photo.py
+++ b/instabot/api/api_photo.py
@@ -85,16 +85,18 @@ def configure_photo(self, upload_id, photo, caption=''):
     return self.send_request('media/configure/?', data)
 
 
-def upload_photo(self, photo, caption=None, upload_id=None, from_video=False):
+def upload_photo(self, photo, caption=None, upload_id=None, from_video=False,
+                 force_rezize=False):
     if upload_id is None:
         upload_id = str(int(time.time() * 1000))
-    if not from_video:
-        photo = resize_image(photo)
     if not photo:
         return False
     if not compatible_aspect_ratio(get_image_size(photo)):
         self.logger.error('Photo does not have a compatible photo aspect ratio.')
-        return False
+        if force_rezize:
+            photo = resize_image(photo)
+        else:
+            return False
 
     with open(photo, 'rb') as f:
         photo_bytes = f.read()


### PR DESCRIPTION
I see this change in https://github.com/instagrambot/instabot/commit/86767249b4be6298f974e8de2f093693ccce8828 and this (in my opinion) should never have been merged.

It just crops on a place that people don't intend, this will always result in a crap photo.