### PR TITLE
Fix: Return abspath of downloaded video

### DIFF
--- a/instabot/api/api.py
+++ b/instabot/api/api.py
@@ -326,8 +326,8 @@ class API(object):
     def configure_story(self, upload_id, photo):
         return configure_story(self, upload_id, photo)
 
-    def upload_video(self, photo, caption=None, upload_id=None):
-        return upload_video(self, photo, caption, upload_id)
+    def upload_video(self, video, caption=None, upload_id=None, thumbnail=None):
+        return upload_video(self, video, caption, upload_id, thumbnail)
 
     def download_video(self, media_id, filename, media=False, folder='video'):
         return download_video(self, media_id, filename, media, folder)

--- a/instabot/api/api.py
+++ b/instabot/api/api.py
@@ -326,8 +326,8 @@ class API(object):
     def configure_story(self, upload_id, photo):
         return configure_story(self, upload_id, photo)
 
-    def upload_video(self, video, caption=None, upload_id=None, thumbnail=None):
-        return upload_video(self, video, caption, upload_id, thumbnail)
+    def upload_video(self, video, caption=None, upload_id=None, thumbnail=None, configure_video_timeout=15):
+        return upload_video(self, video, caption, upload_id, thumbnail, configure_video_timeout)
 
     def download_video(self, media_id, filename, media=False, folder='video'):
         return download_video(self, media_id, filename, media, folder)

--- a/instabot/api/api_video.py
+++ b/instabot/api/api_video.py
@@ -70,10 +70,12 @@ def get_video_info(filename):
     return res
 
 
-def upload_video(self, video, caption=None, upload_id=None):
+def upload_video(self, video, caption=None, upload_id=None, thumbnail=None):
     if upload_id is None:
         upload_id = str(int(time.time() * 1000))
-    video, thumbnail, width, height, duration = resize_video(video)
+    video, thumbnail_path, width, height, duration = resize_video(video)
+    if not thumbnail:
+        thumbnail = thumbnail_path
     data = {
         'upload_id': upload_id,
         '_csrftoken': self.token,

--- a/instabot/api/api_video.py
+++ b/instabot/api/api_video.py
@@ -41,6 +41,8 @@ def download_video(self, media_id, filename=None, media=False, folder='videos'):
                 response.raw.decode_content = True
                 shutil.copyfileobj(response.raw, f)
 
+    return os.path.abspath(fname)
+
 
 # leaving here function used by old upload_video, no more used now
 def get_video_info(filename):

--- a/instabot/api/api_video.py
+++ b/instabot/api/api_video.py
@@ -70,7 +70,7 @@ def get_video_info(filename):
     return res
 
 
-def upload_video(self, video, caption=None, upload_id=None, thumbnail=None):
+def upload_video(self, video, caption=None, upload_id=None, thumbnail=None, configure_video_timeout=15):
     if upload_id is None:
         upload_id = str(int(time.time() * 1000))
     video, thumbnail_path, width, height, duration = resize_video(video)
@@ -134,11 +134,14 @@ def upload_video(self, video, caption=None, upload_id=None, thumbnail=None):
         self.session.headers = headers
 
         if response.status_code == 200:
-            if self.configure_video(upload_id, video, thumbnail, width, height, duration, caption):
-                self.expose()
-                from os import rename
-                rename(video, "{}.REMOVE_ME".format(video))
-                return True
+            for attempt in range(4):
+                if configure_video_timeout:
+                    time.sleep(configure_video_timeout)
+                if self.configure_video(upload_id, video, thumbnail, width, height, duration, caption):
+                    self.expose()
+                    from os import rename
+                    rename(video, "{}.REMOVE_ME".format(video))
+                    return True
     return False
 
 


### PR DESCRIPTION
Now "api.download_video" does not return anything and it is not clear where the file was saved if it was launched like this:

`bot.api.download_video(self.post_id, None, folder='/tmp')`