### PR TITLE
fix ZeroDivisionError when checking user infomation

### DIFF
--- a/instabot/bot/bot_filter.py
+++ b/instabot/bot/bot_filter.py
@@ -198,12 +198,12 @@ def check_user(self, user_id, unfollowing=False):
         skipped.append(user_id)
         return False
     try:
-        if follower_count / following_count > self.max_followers_to_following_ratio:
+        if (following_count > 0) and follower_count / following_count > self.max_followers_to_following_ratio:
             msg = 'follower_count / following_count > bot.max_followers_to_following_ratio, skipping!'
             self.console_print(msg, 'red')
             skipped.append(user_id)
             return False
-        if following_count / follower_count > self.max_following_to_followers_ratio:
+        if (follower_count > 0) and following_count / follower_count > self.max_following_to_followers_ratio:
             msg = 'following_count / follower_count > bot.max_following_to_followers_ratio, skipping!'
             self.console_print(msg, 'red')
             skipped.append(user_id)


### PR DESCRIPTION
When i follow somebody, I meet this error, because the account is following nobody

 ===> Going to follow `user_id`: ***********.

`bot.following` is empty, will download.
Getting followings of ***********.: 100%|█████████████████████████████████]████| 1/1 [00:00<00:00, 12.86it/s]

USER_NAME: ***********., FOLLOWER: 679, FOLLOWING: 0

ZeroDivisionError: division by zero