### PR TITLE
Update devices and Instagram version (maybe can help with action blocked)

### DIFF
--- a/instabot/api/config.py
+++ b/instabot/api/config.py
@@ -10,7 +10,9 @@ USER_AGENT_BASE = (
     '{dpi}; {resolution}; {manufacturer}; '
     '{device}; {model}; {cpu}; en_US)')
 SIG_KEY_VERSION = '4'
-IG_SIG_KEY = '99e16edcca71d7c1f3fd74d447f6281bd5253a623000a55ed0b60014467a53b1'
+
+# IG_SIG_KEY = '99e16edcca71d7c1f3fd74d447f6281bd5253a623000a55ed0b60014467a53b1'
+IG_SIG_KEY = '374b49ca8d2178d4581d15c147ae6a3f42a2f9ca7dad3cbd68c99679caccc65a' # For: Instagram 103.1.0.15.119
 
 # Request variables taken from
 # https://github.com/ping/instagram_private_api/blob/422d61f0a8cc9de3d5a0e78bcba53751c44e5d63/instagram_private_api/client.py#L375

--- a/instabot/api/config.py
+++ b/instabot/api/config.py
@@ -12,7 +12,7 @@ USER_AGENT_BASE = (
 SIG_KEY_VERSION = '4'
 
 # IG_SIG_KEY = '99e16edcca71d7c1f3fd74d447f6281bd5253a623000a55ed0b60014467a53b1'
-IG_SIG_KEY = '374b49ca8d2178d4581d15c147ae6a3f42a2f9ca7dad3cbd68c99679caccc65a' # For: Instagram 103.1.0.15.119
+IG_SIG_KEY = '374b49ca8d2178d4581d15c147ae6a3f42a2f9ca7dad3cbd68c99679caccc65a'  # For: Instagram 103.1.0.15.119
 
 # Request variables taken from
 # https://github.com/ping/instagram_private_api/blob/422d61f0a8cc9de3d5a0e78bcba53751c44e5d63/instagram_private_api/client.py#L375

--- a/instabot/api/devices.py
+++ b/instabot/api/devices.py
@@ -2,7 +2,7 @@
 # https://github.com/mgp25/Instagram-API/blob/master/src/Devices/GoodDevices.php
 DEFAULT_DEVICE = 'one_plus_7'
 DEVICES = {
-	# Released on August 2019
+    # Released on August 2019
     'one_plus_7': {
         'instagram_version': '103.1.0.15.119',
         'android_version': 28,

--- a/instabot/api/devices.py
+++ b/instabot/api/devices.py
@@ -1,7 +1,19 @@
 # Devices taken from
 # https://github.com/mgp25/Instagram-API/blob/master/src/Devices/GoodDevices.php
-DEFAULT_DEVICE = 'samsung_galaxy_s7'
+DEFAULT_DEVICE = 'one_plus_7'
 DEVICES = {
+	# Released on August 2019
+    'one_plus_7': {
+        'instagram_version': '103.1.0.15.119',
+        'android_version': 28,
+        'android_release': '9.0',
+        'dpi': '420dpi',
+        'resolution': '1080x2260',
+        'manufacturer': 'OnePlus',
+        'device': 'GM1903',
+        'model': 'OnePlus7',
+        'cpu': 'qcom'
+    },
     # Released on March 2016
     'samsung_galaxy_s7': {
         'instagram_version': '26.0.0.10.86',


### PR DESCRIPTION
Hi guys! I've updated the devices list with the last version of _Instagram 103.x.x_ running on _OP7_.
Maybe this little fix can help with action blocked.

In the _config.py_ I've also update the IG_SIG_KEY taken from this repo:
https://github.com/itsMoji/Instagram_SSL_Pinning

The user-agent was taken from:
https://developers.whatismybrowser.com/useragents/parse/3782898-instagram-android-oneplus-7-webkit