### PR TITLE
Improve testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,31 @@
 language: python
+dist: xenial
 
 python:
   - "2.7"
   - "3.5"
   - "3.6"
-# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
+  - "3.7"
+  - "3.8-dev"
+  - "nightly"
+  - "pypy"
+  - "pypy3.5"
+
 matrix:
-  include:
-    - python: 3.7
-      dist: xenial
-      sudo: true
+  allow_failures:
+    - python: "3.8-dev"
+    - python: "nightly"
 
 install:
-  - pip install pipenv
-  - pipenv install --dev
+  - pip install tox-travis codecov
 
 script:
- - pyflakes instabot tests examples
- - pycodestyle --ignore=E501 instabot tests
- - pycodestyle --ignore=E402,E501 examples
- - py.test --cov=instabot --cov-report=xml
- - codecov
+ - tox
 
 after_success:
+ - codecov
  - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ]; then bumpversion --verbose minor && bash push.sh; fi
 
-branches:
-  only:
-    - master
 cache: pip
 
 # deploy:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [metadata]
 description-file = README.md
+
+[coverage:run]
+branch = True

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py27,py3{5,6,7,8},pypy{,35}
+skip_missing_interpreters = true
+
+[testenv]
+install_command = {toxinidir}/tox_install_command.sh {opts} {packages}
+commands =
+    pyflakes instabot tests examples
+    pycodestyle --ignore=E501 instabot tests
+    pycodestyle --ignore=E402,E501 examples
+    pytest --cov=instabot --cov-report=xml --cov-report term:skip-covered

--- a/tox_install_command.sh
+++ b/tox_install_command.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+pip install pipenv
+pipenv install --dev --skip-lock


### PR DESCRIPTION
Hello @ohld,

I believe that it would be nice to have tests for the upcoming Python versions and for PyPy.

These changes also:
 - use [tox](https://tox.readthedocs.io/en/latest/) for running tests
 - declare support for Python 3.5 at `setup.py`
 - allow running tests for any branch
 - enable [branch coverage measurement](https://coverage.readthedocs.io/en/latest/branch.html)
 - enable displaying of the coverage

Best regards!