### PR TITLE
fix(login flow): remove return feedback_required

### DIFF
--- a/instabot/api/api.py
+++ b/instabot/api/api.py
@@ -454,7 +454,6 @@ class API(object):
                         "ATTENTION!: `feedback_required`"
                         + str(response_data.get("feedback_message"))
                     )
-                    return "feedback_required"
             except ValueError:
                 self.logger.error(
                     "Error checking for `feedback_required`, "


### PR DESCRIPTION
Returning the required feedback string causes the login stream not to verify
`checkpoint_challenge_required` on line 274 of `instabot/api/api.py`
<img width="786" alt="Screenshot 2019-10-11 at 20 11 07" src="https://user-images.githubusercontent.com/1874493/66678257-61e7a800-ec63-11e9-9c41-e460790b5274.png">
