### PR TITLE
Option to sleep instead of stop action on first block - also fixes pr #969

### DIFF
--- a/instabot/bot/bot.py
+++ b/instabot/bot/bot.py
@@ -169,6 +169,8 @@ class Bot(object):
         stop_words=("shop", "store", "free"),
         blacklist_hashtags=["#shop", "#store", "#free"],
         blocked_actions_protection=True,
+        blocked_actions_sleep=False,
+        blocked_actions_sleep_delay=300,
         verbosity=True,
         device=None,
         save_logfile=True,
@@ -232,6 +234,20 @@ class Bot(object):
         self.blocked_actions_protection = blocked_actions_protection
 
         self.blocked_actions = dict.fromkeys([
+            "likes",
+            "unlikes",
+            "follows",
+            "unfollows",
+            "comments",
+            "blocks",
+            "unblocks",
+            "messages"
+        ], False)
+
+        self.blocked_actions_sleep = blocked_actions_sleep
+        self.blocked_actions_sleep_delay = blocked_actions_sleep_delay
+
+        self.sleeping_actions = dict.fromkeys([
             "likes",
             "unlikes",
             "follows",

--- a/instabot/bot/bot_follow.py
+++ b/instabot/bot/bot_follow.py
@@ -23,16 +23,21 @@ def follow(self, user_id):
             self.logger.error("`Follow` action has been BLOCKED...!!!")
             if not self.blocked_actions_sleep:
                 if self.blocked_actions_protection:
-                    self.logger.warning("Activating blocked actions protection for `Follow` action.")
+                    self.logger.warning("Activating blocked actions \
+                        protection for `Follow` action.")
                     self.blocked_actions["follows"] = True
             else:
-                if self.sleeping_actions["follows"] and self.blocked_actions_protection:
-                    self.logger.warning("This is the second blocked `Follow` action.")
-                    self.logger.warning("Activating blocked actions protection for `Follow` action.")
+                if self.sleeping_actions["follows"] \
+                    and self.blocked_actions_protection:
+                    self.logger.warning("This is the second blocked \
+                        `Follow` action.")
+                    self.logger.warning("Activating blocked actions \
+                        protection for `Follow` action.")
                     self.sleeping_actions["follows"] = False
                     self.blocked_actions["follows"] = True
                 else:
-                    self.logger.info("`Follow` action is going to sleep for %s seconds." % self.blocked_actions_sleep_delay)
+                    self.logger.info("`Follow` action is going to sleep \
+                        for %s seconds." % self.blocked_actions_sleep_delay)
                     self.sleeping_actions["follows"] = True
                     time.sleep(self.blocked_actions_sleep_delay)
             return False

--- a/instabot/bot/bot_follow.py
+++ b/instabot/bot/bot_follow.py
@@ -21,7 +21,20 @@ def follow(self, user_id):
         _r = self.api.follow(user_id)
         if _r == "feedback_required":
             self.logger.error("`Follow` action has been BLOCKED...!!!")
-            self.blocked_actions["follows"] = True
+            if not self.blocked_actions_sleep:
+                if self.blocked_actions_protection:
+                    self.logger.warning("Activating blocked actions protection for `Follow` action.")
+                    self.blocked_actions["follows"] = True
+            else:
+                if self.sleeping_actions["follows"] and self.blocked_actions_protection:
+                    self.logger.warning("This is the second blocked `Follow` action.")
+                    self.logger.warning("Activating blocked actions protection for `Follow` action.")
+                    self.sleeping_actions["follows"] = False
+                    self.blocked_actions["follows"] = True
+                else:
+                    self.logger.info("`Follow` action is going to sleep for %s seconds." % self.blocked_actions_sleep_delay)
+                    self.sleeping_actions["follows"] = True
+                    time.sleep(self.blocked_actions_sleep_delay)
             return False
         if _r:
             msg = "===> FOLLOWED <==== `user_id`: {}.".format(user_id)
@@ -30,6 +43,9 @@ def follow(self, user_id):
             self.followed_file.append(user_id)
             if user_id not in self.following:
                 self.following.append(user_id)
+            if self.blocked_actions_sleep and self.sleeping_actions["follows"]:
+                self.logger.info("`Follow` action is no longer sleeping.")
+                self.sleeping_actions["follows"] = False
             return True
     else:
         self.logger.info("Out of follows for today.")

--- a/instabot/bot/bot_follow.py
+++ b/instabot/bot/bot_follow.py
@@ -28,7 +28,7 @@ def follow(self, user_id):
                     self.blocked_actions["follows"] = True
             else:
                 if self.sleeping_actions["follows"] \
-                    and self.blocked_actions_protection:
+                and self.blocked_actions_protection:
                     self.logger.warning("This is the second blocked \
                         `Follow` action.")
                     self.logger.warning("Activating blocked actions \

--- a/instabot/bot/bot_follow.py
+++ b/instabot/bot/bot_follow.py
@@ -28,7 +28,7 @@ def follow(self, user_id):
                     self.blocked_actions["follows"] = True
             else:
                 if self.sleeping_actions["follows"] \
-                and self.blocked_actions_protection:
+                        and self.blocked_actions_protection:
                     self.logger.warning("This is the second blocked \
                         `Follow` action.")
                     self.logger.warning("Activating blocked actions \

--- a/instabot/bot/bot_like.py
+++ b/instabot/bot/bot_like.py
@@ -1,6 +1,7 @@
 from tqdm import tqdm
 import time
 
+
 def like(
     self,
     media_id,
@@ -54,21 +55,29 @@ def like(
         )
         if _r == "feedback_required":
             self.logger.error("`Like` action has been BLOCKED...!!!")
-            # if no sleep enabled, default flow, with message of activating blocked actions protection
+            # if no sleep enabled, default flow, 
+            # with message of activating blocked actions protection
             if not self.blocked_actions_sleep:
                 if self.blocked_actions_protection:
-                    self.logger.warning("Activating blocked actions protection for `Like` action.")
+                    self.logger.warning("Activating blocked actions \
+                         protection for `Like` action.")
                     self.blocked_actions["likes"] = True
             else:
-                # if the action is sleeping and another block, then enable blocked actions protection
-                if self.sleeping_actions["likes"] and self.blocked_actions_protection:
-                    self.logger.warning("This is the second blocked `Like` action.")
-                    self.logger.warning("Activating blocked actions protection for `Like` action.")
+                # if the action is sleeping and another block, 
+                # then enable blocked actions protection
+                if self.sleeping_actions["likes"] \
+                    and self.blocked_actions_protection:
+                    self.logger.warning("This is the second blocked \
+                        `Like` action.")
+                    self.logger.warning("Activating blocked actions \
+                        protection for `Like` action.")
                     self.sleeping_actions["likes"] = False
                     self.blocked_actions["likes"] = True
-                # otherwise (first block or no protection) sleep for specified time
+                # otherwise (first block or no protection) 
+                # sleep for specified time
                 else:
-                    self.logger.info("`Like` action is going to sleep for %s seconds." % self.blocked_actions_sleep_delay)
+                    self.logger.info("`Like` action is going to sleep for \
+                        %s seconds." % self.blocked_actions_sleep_delay)
                     self.sleeping_actions["likes"] = True
                     time.sleep(self.blocked_actions_sleep_delay)
             return False

--- a/instabot/bot/bot_like.py
+++ b/instabot/bot/bot_like.py
@@ -55,7 +55,7 @@ def like(
         )
         if _r == "feedback_required":
             self.logger.error("`Like` action has been BLOCKED...!!!")
-            # if no sleep enabled, default flow, 
+            # if no sleep enabled, default flow,
             # with message of activating blocked actions protection
             if not self.blocked_actions_sleep:
                 if self.blocked_actions_protection:
@@ -63,17 +63,17 @@ def like(
                          protection for `Like` action.")
                     self.blocked_actions["likes"] = True
             else:
-                # if the action is sleeping and another block, 
+                # if the action is sleeping and another block,
                 # then enable blocked actions protection
                 if self.sleeping_actions["likes"] \
-                    and self.blocked_actions_protection:
+                and self.blocked_actions_protection:
                     self.logger.warning("This is the second blocked \
                         `Like` action.")
                     self.logger.warning("Activating blocked actions \
                         protection for `Like` action.")
                     self.sleeping_actions["likes"] = False
                     self.blocked_actions["likes"] = True
-                # otherwise (first block or no protection) 
+                # otherwise (first block or no protection)
                 # sleep for specified time
                 else:
                     self.logger.info("`Like` action is going to sleep for \

--- a/instabot/bot/bot_like.py
+++ b/instabot/bot/bot_like.py
@@ -66,7 +66,7 @@ def like(
                 # if the action is sleeping and another block,
                 # then enable blocked actions protection
                 if self.sleeping_actions["likes"] \
-                and self.blocked_actions_protection:
+                        and self.blocked_actions_protection:
                     self.logger.warning("This is the second blocked \
                         `Like` action.")
                     self.logger.warning("Activating blocked actions \

--- a/instabot/bot/bot_like.py
+++ b/instabot/bot/bot_like.py
@@ -1,5 +1,5 @@
 from tqdm import tqdm
-
+import time
 
 def like(
     self,
@@ -54,11 +54,31 @@ def like(
         )
         if _r == "feedback_required":
             self.logger.error("`Like` action has been BLOCKED...!!!")
-            self.blocked_actions["likes"] = True
+            # if no sleep enabled, default flow, with message of activating blocked actions protection
+            if not self.blocked_actions_sleep:
+                if self.blocked_actions_protection:
+                    self.logger.warning("Activating blocked actions protection for `Like` action.")
+                    self.blocked_actions["likes"] = True
+            else:
+                # if the action is sleeping and another block, then enable blocked actions protection
+                if self.sleeping_actions["likes"] and self.blocked_actions_protection:
+                    self.logger.warning("This is the second blocked `Like` action.")
+                    self.logger.warning("Activating blocked actions protection for `Like` action.")
+                    self.sleeping_actions["likes"] = False
+                    self.blocked_actions["likes"] = True
+                # otherwise (first block or no protection) sleep for specified time
+                else:
+                    self.logger.info("`Like` action is going to sleep for %s seconds." % self.blocked_actions_sleep_delay)
+                    self.sleeping_actions["likes"] = True
+                    time.sleep(self.blocked_actions_sleep_delay)
             return False
         if _r:
             self.logger.info("Liked media %s." % media_id)
             self.total["likes"] += 1
+            # if action just slept and now successful, then no longer sleeping
+            if self.blocked_actions_sleep and self.sleeping_actions["likes"]:
+                self.logger.info("`Like` action is no longer sleeping.")
+                self.sleeping_actions["likes"] = False
             return True
     else:
         self.logger.info("Out of likes for today.")

--- a/instabot/bot/bot_unfollow.py
+++ b/instabot/bot/bot_unfollow.py
@@ -1,5 +1,5 @@
 from tqdm import tqdm
-
+import time
 
 def unfollow(self, user_id):
     user_id = self.convert_to_user_id(user_id)
@@ -32,7 +32,20 @@ def unfollow(self, user_id):
         _r = self.api.unfollow(user_id)
         if _r == "feedback_required":
             self.logger.error("`Unfollow` action has been BLOCKED...!!!")
-            self.blocked_actions["unfollows"] = True
+            if not self.blocked_actions_sleep:
+                if self.blocked_actions_protection:
+                    self.logger.warning("Activating blocked actions protection for `Unfollow` action.")
+                    self.blocked_actions["unfollows"] = True
+            else:
+                if self.sleeping_actions["unfollows"] and self.blocked_actions_protection:
+                    self.logger.warning("This is the second blocked `Unfollow` action.")
+                    self.logger.warning("Activating blocked actions protection for `Unfollow` action.")
+                    self.sleeping_actions["unfollows"] = False
+                    self.blocked_actions["unfollows"] = True
+                else:
+                    self.logger.info("`Unfollow` action is going to sleep for %s seconds." % self.blocked_actions_sleep_delay)
+                    self.sleeping_actions["unfollows"] = True
+                    time.sleep(self.blocked_actions_sleep_delay)
             return False
         if _r:
             msg = "===> Unfollowed, `user_id`: {}, user_name: {}"
@@ -41,6 +54,9 @@ def unfollow(self, user_id):
             self.total["unfollows"] += 1
             if user_id in self.following:
                 self.following.remove(user_id)
+            if self.blocked_actions_sleep and self.sleeping_actions["unfollows"]:
+                self.logger.info("`Unfollow` action is no longer sleeping.")
+                self.sleeping_actions["unfollows"] = False
             return True
     else:
         self.logger.info("Out of unfollows for today.")

--- a/instabot/bot/bot_unfollow.py
+++ b/instabot/bot/bot_unfollow.py
@@ -40,7 +40,7 @@ def unfollow(self, user_id):
                     self.blocked_actions["unfollows"] = True
             else:
                 if self.sleeping_actions["unfollows"] \
-                and self.blocked_actions_protection:
+                        and self.blocked_actions_protection:
                     self.logger.warning("This is the second blocked \
                         `Unfollow` action.")
                     self.logger.warning("Activating blocked actions \
@@ -61,7 +61,7 @@ def unfollow(self, user_id):
             if user_id in self.following:
                 self.following.remove(user_id)
             if self.blocked_actions_sleep \
-            and self.sleeping_actions["unfollows"]:
+                    and self.sleeping_actions["unfollows"]:
                 self.logger.info("`Unfollow` action is no longer sleeping.")
                 self.sleeping_actions["unfollows"] = False
             return True

--- a/instabot/bot/bot_unfollow.py
+++ b/instabot/bot/bot_unfollow.py
@@ -40,7 +40,7 @@ def unfollow(self, user_id):
                     self.blocked_actions["unfollows"] = True
             else:
                 if self.sleeping_actions["unfollows"] \
-                    and self.blocked_actions_protection:
+                and self.blocked_actions_protection:
                     self.logger.warning("This is the second blocked \
                         `Unfollow` action.")
                     self.logger.warning("Activating blocked actions \
@@ -61,7 +61,7 @@ def unfollow(self, user_id):
             if user_id in self.following:
                 self.following.remove(user_id)
             if self.blocked_actions_sleep \
-                and self.sleeping_actions["unfollows"]:
+            and self.sleeping_actions["unfollows"]:
                 self.logger.info("`Unfollow` action is no longer sleeping.")
                 self.sleeping_actions["unfollows"] = False
             return True

--- a/instabot/bot/bot_unfollow.py
+++ b/instabot/bot/bot_unfollow.py
@@ -1,6 +1,7 @@
 from tqdm import tqdm
 import time
 
+
 def unfollow(self, user_id):
     user_id = self.convert_to_user_id(user_id)
     user_info = self.get_user_info(user_id)
@@ -34,16 +35,21 @@ def unfollow(self, user_id):
             self.logger.error("`Unfollow` action has been BLOCKED...!!!")
             if not self.blocked_actions_sleep:
                 if self.blocked_actions_protection:
-                    self.logger.warning("Activating blocked actions protection for `Unfollow` action.")
+                    self.logger.warning("Activating blocked actions \
+                        protection for `Unfollow` action.")
                     self.blocked_actions["unfollows"] = True
             else:
-                if self.sleeping_actions["unfollows"] and self.blocked_actions_protection:
-                    self.logger.warning("This is the second blocked `Unfollow` action.")
-                    self.logger.warning("Activating blocked actions protection for `Unfollow` action.")
+                if self.sleeping_actions["unfollows"] \
+                    and self.blocked_actions_protection:
+                    self.logger.warning("This is the second blocked \
+                        `Unfollow` action.")
+                    self.logger.warning("Activating blocked actions \
+                        protection for `Unfollow` action.")
                     self.sleeping_actions["unfollows"] = False
                     self.blocked_actions["unfollows"] = True
                 else:
-                    self.logger.info("`Unfollow` action is going to sleep for %s seconds." % self.blocked_actions_sleep_delay)
+                    self.logger.info("`Unfollow` action is going to sleep \
+                        for %s seconds." % self.blocked_actions_sleep_delay)
                     self.sleeping_actions["unfollows"] = True
                     time.sleep(self.blocked_actions_sleep_delay)
             return False
@@ -54,7 +60,8 @@ def unfollow(self, user_id):
             self.total["unfollows"] += 1
             if user_id in self.following:
                 self.following.remove(user_id)
-            if self.blocked_actions_sleep and self.sleeping_actions["unfollows"]:
+            if self.blocked_actions_sleep \
+                and self.sleeping_actions["unfollows"]:
                 self.logger.info("`Unfollow` action is no longer sleeping.")
                 self.sleeping_actions["unfollows"] = False
             return True


### PR DESCRIPTION
Adds a new option blocked_actions_sleep (default False for compatibility) and an associated blocked_actions_sleep_delay (default 300 sec = 5 min) that does the following:

If blocked_actions_sleep is True, the first instance of a blocked action (like, follow, unfollow) will trigger a sleep for the specified time, instead of immediately skipping it. If the action is not blocked after the sleep, it will continue running as normal.

If the action continues to be blocked, and blocked_actions_protection is active, the action will be skipped.
If blocked_actions_protection is inactive, a sleep will occur every time the action is blocked.

(Note, this is similar to the flow outlined in https://github.com/instagrambot/instabot/pull/969#issuecomment-517919647 ) 

I want to add this feature so that short blocks (5-10 min) can be slept through while also not lengthening the block period by making too many requests.