### PR TITLE
New tests for blocked_actions_protection find that it doesn't activate when expected

### DIFF
--- a/instabot/api/api.py
+++ b/instabot/api/api.py
@@ -16,6 +16,7 @@ import requests.utils
 import six.moves.urllib as urllib
 from requests_toolbelt import MultipartEncoder
 from tqdm import tqdm
+import traceback
 
 from . import config, devices
 from .api_login import (
@@ -449,13 +450,14 @@ class API(object):
                 )
             try:
                 response_data = json.loads(response.text)
-                if "feedback_required" in str(response_data.get("message")):
+                if "feedback_required" in str(response_data.get("message").encode('utf-8')):
                     self.logger.error(
                         "ATTENTION!: `feedback_required`"
-                        + str(response_data.get("feedback_message"))
+                        + str(response_data.get("feedback_message").encode('utf-8'))
                     )
                     return "feedback_required"
             except ValueError:
+                self.logger.error(traceback.format_exc())
                 self.logger.error(
                     "Error checking for `feedback_required`, "
                     "response text is not JSON"

--- a/instabot/api/api.py
+++ b/instabot/api/api.py
@@ -450,7 +450,7 @@ class API(object):
             try:
                 response_data = json.loads(response.text)
                 if "feedback_required" in str(
-                        response_data.get("message").encode('utf-8')):
+                        response_data.get("message")):
                     self.logger.error(
                         "ATTENTION!: `feedback_required`"
                         + str(response_data.get("feedback_message"

--- a/instabot/api/api.py
+++ b/instabot/api/api.py
@@ -435,6 +435,7 @@ class API(object):
             return False
 
         self.last_response = response
+        self.logger.debug(response)
         if response.status_code == 200:
             try:
                 self.last_json = json.loads(response.text)
@@ -449,8 +450,9 @@ class API(object):
                 )
             try:
                 response_data = json.loads(response.text)
-                if "feedback_required" in str(
-                        response_data.get("message")):
+                if response_data.get("message") is not None \
+                    and "feedback_required" in str(
+                        response_data.get("message").encode('utf-8')):
                     self.logger.error(
                         "ATTENTION!: `feedback_required`"
                         + str(response_data.get(

--- a/instabot/api/api.py
+++ b/instabot/api/api.py
@@ -454,6 +454,7 @@ class API(object):
                         "ATTENTION!: `feedback_required`"
                         + str(response_data.get("feedback_message"))
                     )
+                    return "feedback_required"
             except ValueError:
                 self.logger.error(
                     "Error checking for `feedback_required`, "

--- a/instabot/api/api.py
+++ b/instabot/api/api.py
@@ -456,7 +456,8 @@ class API(object):
                         + str(response_data.get(
                             "feedback_message").encode('utf-8'))
                     )
-                    return "feedback_required"
+                    if not response_data.get("two_factor_required"):
+                        return "feedback_required"
             except ValueError:
                 self.logger.error(
                     "Error checking for `feedback_required`, "

--- a/instabot/api/api.py
+++ b/instabot/api/api.py
@@ -284,9 +284,68 @@ class API(object):
                         return False
                 else:
                     return False
+            elif self.last_json.get("two_factor_required"):
+                if two_factor_auth(self):
+                    self.save_successful_login()
+                    self.login_flow(True)
+                    return True
+                else:
+                    self.save_failed_login()
+                    return False
             else:
                 self.save_failed_login()
                 return False
+
+    def two_factor_auth(self):
+        self.logger.info("Two-factor authentication required")
+        two_factor_code = input("Enter 2FA verification code: ")
+        two_factor_id = self.last_json["two_factor_info"][
+            "two_factor_identifier"
+        ]
+
+        login = self.session.post(
+            config.API_URL + "accounts/two_factor_login/",
+            data={
+                "username": self.username,
+                "verification_code": two_factor_code,
+                "two_factor_identifier": two_factor_id,
+                "password": self.password,
+                "device_id": self.device_id,
+                "ig_sig_key_version": 4,
+            },
+            allow_redirects=True,
+        )
+
+        if login.status_code == 200:
+            resp_json = json.loads(login.text)
+            if resp_json["status"] != "ok":
+                if "message" in resp_json:
+                    self.logger.error(
+                        "Login error: {}".format(
+                            resp_json["message"]
+                        )
+                    )
+                else:
+                    self.logger.error(
+                        (
+                            'Login error: "{}" status and'
+                            ' message {}.'
+                        ).format(
+                            resp_json["status"], login.text
+                        )
+                    )
+                return False
+            return True
+        else:
+            self.logger.error(
+                (
+                    "Two-factor authentication request returns "
+                    "{} error with message {} !"
+                ).format(
+                    login.status_code, login.text
+                )
+            )
+            return False
 
     def save_successful_login(self):
         self.is_logged_in = True
@@ -458,6 +517,12 @@ class API(object):
                         + str(response_data.get(
                             "feedback_message").encode('utf-8'))
                     )
+                    try:
+                        self.last_response = response
+                        self.last_json = json.loads(response.text)
+                    except Exception:
+                        pass
+                    return "feedback_required"
             except ValueError:
                 self.logger.error(
                     "Error checking for `feedback_required`, "
@@ -476,55 +541,12 @@ class API(object):
 
                 # PERFORM Interactive Two-Factor Authentication
                 if response_data.get("two_factor_required"):
-                    self.logger.info("Two-factor authentication required")
-                    two_factor_code = input("Enter 2FA verification code: ")
-                    two_factor_id = response_data["two_factor_info"][
-                        "two_factor_identifier"
-                    ]
-
-                    login = self.session.post(
-                        config.API_URL + "accounts/two_factor_login/",
-                        data={
-                            "username": self.username,
-                            "verification_code": two_factor_code,
-                            "two_factor_identifier": two_factor_id,
-                            "password": self.password,
-                            "device_id": self.device_id,
-                            "ig_sig_key_version": 4,
-                        },
-                        allow_redirects=True,
-                    )
-
-                    if login.status_code == 200:
-                        resp_json = json.loads(login.text)
-                        if resp_json["status"] != "ok":
-                            if "message" in resp_json:
-                                self.logger.error(
-                                    "Login error: {}".format(
-                                        resp_json["message"]
-                                    )
-                                )
-                            else:
-                                self.logger.error(
-                                    (
-                                        'Login error: "{}" status and'
-                                        ' message {}.'
-                                    ).format(
-                                        resp_json["status"], login.text
-                                    )
-                                )
-                            return False
-                        return True
-                    else:
-                        self.logger.error(
-                            (
-                                "Two-factor authentication request returns "
-                                "{} error with message {} !"
-                            ).format(
-                                login.status_code, login.text
-                            )
-                        )
-                        return False
+                    try:
+                        self.last_response = response
+                        self.last_json = json.loads(response.text)
+                    except Exception:
+                        pass
+                    return self.two_factor_auth()
                 # End of Interactive Two-Factor Authentication
                 else:
                     msg = "Instagram's error message: {}"

--- a/instabot/api/api.py
+++ b/instabot/api/api.py
@@ -458,8 +458,6 @@ class API(object):
                         + str(response_data.get(
                             "feedback_message").encode('utf-8'))
                     )
-                    if not response_data.get("two_factor_required"):
-                        return "feedback_required"
             except ValueError:
                 self.logger.error(
                     "Error checking for `feedback_required`, "

--- a/instabot/api/api.py
+++ b/instabot/api/api.py
@@ -16,7 +16,6 @@ import requests.utils
 import six.moves.urllib as urllib
 from requests_toolbelt import MultipartEncoder
 from tqdm import tqdm
-import traceback
 
 from . import config, devices
 from .api_login import (
@@ -450,14 +449,15 @@ class API(object):
                 )
             try:
                 response_data = json.loads(response.text)
-                if "feedback_required" in str(response_data.get("message").encode('utf-8')):
+                if "feedback_required" in str(
+                        response_data.get("message").encode('utf-8')):
                     self.logger.error(
                         "ATTENTION!: `feedback_required`"
-                        + str(response_data.get("feedback_message").encode('utf-8'))
+                        + str(response_data.get("feedback_message"
+                        ).encode('utf-8'))
                     )
                     return "feedback_required"
             except ValueError:
-                self.logger.error(traceback.format_exc())
                 self.logger.error(
                     "Error checking for `feedback_required`, "
                     "response text is not JSON"

--- a/instabot/api/api.py
+++ b/instabot/api/api.py
@@ -453,8 +453,8 @@ class API(object):
                         response_data.get("message")):
                     self.logger.error(
                         "ATTENTION!: `feedback_required`"
-                        + str(response_data.get("feedback_message"
-                        ).encode('utf-8'))
+                        + str(response_data.get(
+                            "feedback_message").encode('utf-8'))
                     )
                     return "feedback_required"
             except ValueError:

--- a/instabot/bot/bot.py
+++ b/instabot/bot/bot.py
@@ -813,8 +813,8 @@ class Bot(object):
         )
 
     # follow
-    def follow(self, user_id):
-        return follow(self, user_id)
+    def follow(self, user_id, check_user=True):
+        return follow(self, user_id, check_user)
 
     def follow_users(self, user_ids, nfollows=None):
         return follow_users(self, user_ids, nfollows)

--- a/instabot/bot/bot_follow.py
+++ b/instabot/bot/bot_follow.py
@@ -2,7 +2,7 @@ import time
 from tqdm import tqdm
 
 
-def follow(self, user_id):
+def follow(self, user_id, check_user):
     user_id = self.convert_to_user_id(user_id)
     if self.log_follow_unfollow:
         msg = "Going to follow `user_id` {}.".format(user_id)
@@ -10,7 +10,7 @@ def follow(self, user_id):
     else:
         msg = " ===> Going to follow `user_id`: {}.".format(user_id)
         self.console_print(msg)
-    if not self.check_user(user_id):
+    if check_user and not self.check_user(user_id):
         return False
     if not self.reached_limit("follows"):
         if self.blocked_actions["follows"]:

--- a/tests/test_bot_like.py
+++ b/tests/test_bot_like.py
@@ -591,12 +591,12 @@ class TestBotGet(TestBot):
     @responses.activate
     @pytest.mark.parametrize(
         "blocked_actions_protection,blocked_actions_sleep,result",
-        [(True, True, False), (True, False, True), 
-        (False, True, False), (False, False, False)],
+        [(True, True, False), (True, False, True),
+         (False, True, False), (False, False, False)],
     )
     @patch("time.sleep", return_value=None)
     def test_sleep_feedback_successful(
-        self, patched_time_sleep, blocked_actions_protection, 
+        self, patched_time_sleep, blocked_actions_protection,
         blocked_actions_sleep, result
     ):
         self.bot.blocked_actions_protection = blocked_actions_protection
@@ -644,12 +644,12 @@ class TestBotGet(TestBot):
     @responses.activate
     @pytest.mark.parametrize(
         "blocked_actions_protection,blocked_actions_sleep,result",
-        [(True, True, True), (True, False, True), 
-        (False, True, False), (False, False, False)],
+        [(True, True, True), (True, False, True),
+         (False, True, False), (False, False, False)],
     )
     @patch("time.sleep", return_value=None)
     def test_sleep_feedback_unsuccessful(
-        self, patched_time_sleep, blocked_actions_protection, 
+        self, patched_time_sleep, blocked_actions_protection,
         blocked_actions_sleep, result
     ):
         self.bot.blocked_actions_protection = blocked_actions_protection

--- a/tests/test_bot_like.py
+++ b/tests/test_bot_like.py
@@ -590,6 +590,100 @@ class TestBotGet(TestBot):
 
     @responses.activate
     @pytest.mark.parametrize(
+        "blocked_actions_protection,blocked_actions_sleep,result",
+        [(True, True, False), (True, False, True), (False, True, False), (False, False, False)],
+    )
+    @patch("time.sleep", return_value=None)
+    def test_sleep_feedback_successful(
+        self, patched_time_sleep, blocked_actions_protection, blocked_actions_sleep, result
+    ):
+        self.bot.blocked_actions_protection = blocked_actions_protection
+        # self.bot.blocked_actions["likes"] = False
+        self.bot.blocked_actions_sleep = blocked_actions_sleep
+        media_id = 1234567890
+        response_data = {
+            u"status": u"fail",
+            u"feedback_title": u"You\u2019re Temporarily Blocked",
+            u"feedback_message": u"It looks like you were misusing this " +
+            u"feature by going too fast. You\u2019ve been temporarily " +
+            u"blocked from using it. We restrict certain content and " +
+            u"actions to protect our community. Tell us if you think we " +
+            u"made a mistake.",
+            u"spam": True,
+            u"feedback_action": u"report_problem",
+            u"feedback_appeal_label": u"Report problem",
+            u"feedback_ignore_label": u"OK",
+            u"message": u"feedback_required",
+            u"feedback_url": u"repute/report_problem/instagram_like_add/",
+        }
+        # first like blocked
+        responses.add(
+            responses.POST,
+            "{api_url}media/{media_id}/like/".format(
+                api_url=API_URL, media_id=media_id
+            ),
+            json=response_data,
+            status=400,
+        )
+        # second like successful
+        responses.add(
+            responses.POST,
+            "{api_url}media/{media_id}/like/".format(
+                api_url=API_URL, media_id=media_id
+            ),
+            status=200,
+            json={"status": "ok"},
+        )
+        # do 2 likes
+        self.bot.like(media_id, check_media=False)
+        self.bot.like(media_id, check_media=False)
+        assert self.bot.blocked_actions["likes"] == result
+
+    @responses.activate
+    @pytest.mark.parametrize(
+        "blocked_actions_protection,blocked_actions_sleep,result",
+        [(True, True, True), (True, False, True), (False, True, False), (False, False, False)],
+    )
+    @patch("time.sleep", return_value=None)
+    def test_sleep_feedback_unsuccessful(
+        self, patched_time_sleep, blocked_actions_protection, blocked_actions_sleep, result
+    ):
+        self.bot.blocked_actions_protection = blocked_actions_protection
+        # self.bot.blocked_actions["likes"] = False
+        self.bot.blocked_actions_sleep = blocked_actions_sleep
+        media_id = 1234567890
+        response_data = {
+            u"status": u"fail",
+            u"feedback_title": u"You\u2019re Temporarily Blocked",
+            u"feedback_message": u"It looks like you were misusing this " +
+            u"feature by going too fast. You\u2019ve been temporarily " +
+            u"blocked from using it. We restrict certain content and " +
+            u"actions to protect our community. Tell us if you think we " +
+            u"made a mistake.",
+            u"spam": True,
+            u"feedback_action": u"report_problem",
+            u"feedback_appeal_label": u"Report problem",
+            u"feedback_ignore_label": u"OK",
+            u"message": u"feedback_required",
+            u"feedback_url": u"repute/report_problem/instagram_like_add/",
+        }
+        # both likes blocked
+        for x in range (1, 2):
+            responses.add(
+                responses.POST,
+                "{api_url}media/{media_id}/like/".format(
+                    api_url=API_URL, media_id=media_id
+                ),
+                json=response_data,
+                status=400,
+            )
+        # do 2 likes
+        self.bot.like(media_id, check_media=False)
+        self.bot.like(media_id, check_media=False)
+        assert self.bot.blocked_actions["likes"] == result
+
+    @responses.activate
+    @pytest.mark.parametrize(
         "blocked_actions_protection,blocked_actions",
         [(True, True), (True, False), (False, True), (False, True)],
     )

--- a/tests/test_bot_like.py
+++ b/tests/test_bot_like.py
@@ -591,11 +591,13 @@ class TestBotGet(TestBot):
     @responses.activate
     @pytest.mark.parametrize(
         "blocked_actions_protection,blocked_actions_sleep,result",
-        [(True, True, False), (True, False, True), (False, True, False), (False, False, False)],
+        [(True, True, False), (True, False, True), 
+        (False, True, False), (False, False, False)],
     )
     @patch("time.sleep", return_value=None)
     def test_sleep_feedback_successful(
-        self, patched_time_sleep, blocked_actions_protection, blocked_actions_sleep, result
+        self, patched_time_sleep, blocked_actions_protection, 
+        blocked_actions_sleep, result
     ):
         self.bot.blocked_actions_protection = blocked_actions_protection
         # self.bot.blocked_actions["likes"] = False
@@ -642,11 +644,13 @@ class TestBotGet(TestBot):
     @responses.activate
     @pytest.mark.parametrize(
         "blocked_actions_protection,blocked_actions_sleep,result",
-        [(True, True, True), (True, False, True), (False, True, False), (False, False, False)],
+        [(True, True, True), (True, False, True), 
+        (False, True, False), (False, False, False)],
     )
     @patch("time.sleep", return_value=None)
     def test_sleep_feedback_unsuccessful(
-        self, patched_time_sleep, blocked_actions_protection, blocked_actions_sleep, result
+        self, patched_time_sleep, blocked_actions_protection, 
+        blocked_actions_sleep, result
     ):
         self.bot.blocked_actions_protection = blocked_actions_protection
         # self.bot.blocked_actions["likes"] = False
@@ -668,7 +672,7 @@ class TestBotGet(TestBot):
             u"feedback_url": u"repute/report_problem/instagram_like_add/",
         }
         # both likes blocked
-        for x in range (1, 2):
+        for x in range(1, 2):
             responses.add(
                 responses.POST,
                 "{api_url}media/{media_id}/like/".format(


### PR DESCRIPTION
This pr started with me trying to write tests for the recently added blocked_actions_sleep functionality; however, upon finding the tests failing, I found that the api send_request() method was not returning "feedback_required" upon hitting a block (see https://github.com/instagrambot/instabot/issues/1087#issuecomment-542549855). Therefore, a second commit was added to reinstate the return value of "feedback_required" (which was present in an earlier version, but seemed to have been removed somewhere).