### PR TITLE
Updated version method to be static

### DIFF
--- a/instabot/bot/bot.py
+++ b/instabot/bot/bot.py
@@ -373,7 +373,8 @@ class Bot(object):
             self.last["updated_followers"] = now
         return self._followers
 
-    def version(self):
+    @staticmethod
+    def version():
         try:
             from pip._vendor import pkg_resources
         except ImportError:


### PR DESCRIPTION
You shouldn't have to instantiate an object to get the version and the version method doesn't use self at all so easy change