### PR TITLE
Repeat request after 429 error

### DIFF
--- a/instabot/api/api.py
+++ b/instabot/api/api.py
@@ -494,6 +494,7 @@ class API(object):
                     "for {} minutes.".format(sleep_minutes)
                 )
                 time.sleep(sleep_minutes * 60)
+                return self.send_request(endpoint, post, login, with_signature, headers, extra_sig)
             elif response.status_code == 400:
                 response_data = json.loads(response.text)
 

--- a/instabot/api/api.py
+++ b/instabot/api/api.py
@@ -494,7 +494,9 @@ class API(object):
                     "for {} minutes.".format(sleep_minutes)
                 )
                 time.sleep(sleep_minutes * 60)
-                return self.send_request(endpoint, post, login, with_signature, headers, extra_sig)
+                return self.send_request(
+                    endpoint, post, login, with_signature, headers, extra_sig
+                )
             elif response.status_code == 400:
                 response_data = json.loads(response.text)
 


### PR DESCRIPTION
If a 429 error is returned by Instagram, the request will simply be skipped, instead of be repeated. This commit changes that behaviour.