### PR TITLE
Updated private account warning for clarity

### DIFF
--- a/instabot/bot/bot_get.py
+++ b/instabot/bot/bot_get.py
@@ -89,7 +89,7 @@ def get_user_medias(self, user_id, filtration=True, is_comment=False):
     user_id = self.convert_to_user_id(user_id)
     self.api.get_user_feed(user_id)
     if self.api.last_json["status"] == "fail":
-        self.logger.warning("This is a closed account.")
+        self.logger.warning("This is a private account.")
         return []
     return self.filter_medias(
         self.api.last_json.get("items"), filtration, is_comment=is_comment
@@ -100,7 +100,7 @@ def get_total_user_medias(self, user_id):
     user_id = self.convert_to_user_id(user_id)
     medias = self.api.get_total_user_feed(user_id)
     if self.api.last_json["status"] == "fail":
-        self.logger.warning("This is a closed account.")
+        self.logger.warning("This is a private account.")
         return []
     return self.filter_medias(medias, filtration=False)
 
@@ -109,7 +109,7 @@ def get_last_user_medias(self, user_id, amount):
     user_id = self.convert_to_user_id(user_id)
     medias = self.api.get_last_user_feed(user_id, amount)
     if self.api.last_json["status"] == "fail":
-        self.logger.warning("This is a closed account.")
+        self.logger.warning("This is a private account.")
         return []
     return self.filter_medias(medias, filtration=False)
 


### PR DESCRIPTION
Using 'closed account' makes it sound like the account has been closed by instagram not that the account is closed off from the public.