### PR TITLE
Bugfix set_proxy after each send_request, not only for login

### DIFF
--- a/instabot/api/api.py
+++ b/instabot/api/api.py
@@ -444,7 +444,7 @@ class API(object):
         return not self.is_logged_in
 
     def set_proxy(self):
-        if self.proxy:
+        if getattr(self, 'proxy', None):
             parsed = urllib.parse.urlparse(self.proxy)
             scheme = "http://" if not parsed.scheme else ""
             self.session.proxies["http"] = scheme + self.proxy

--- a/instabot/api/api.py
+++ b/instabot/api/api.py
@@ -456,6 +456,7 @@ class API(object):
         headers=None,
         extra_sig=None,
     ):
+        self.set_proxy()  # Only happens if `self.proxy`
         if not self.is_logged_in and not login:
             msg = "Not logged in!"
             self.logger.critical(msg)

--- a/instabot/api/api_video.py
+++ b/instabot/api/api_video.py
@@ -39,14 +39,13 @@ def download_video(
     except Exception:
         return False
 
-    fname = os.path.join(folder, filename)
-    if os.path.exists(fname):
-        return os.path.abspath(fname)
-
     for counter, video_url in enumerate(video_urls):
+        fname = os.path.join(folder, "{}_{}".format(counter, filename))
+        if os.path.exists(fname):
+            print('File %s is exists, return it' % fname)
+            return os.path.abspath(fname)
         response = self.session.get(video_url, stream=True)
         if response.status_code == 200:
-            fname = os.path.join(folder, "{}_{}".format(counter, filename))
             with open(fname, "wb") as f:
                 response.raw.decode_content = True
                 shutil.copyfileobj(response.raw, f)


### PR DESCRIPTION
Now set_proxy is called upon login, requests to the login pass without a proxy, because of this, Instagram does not allow access to the login

This fix will allow you to set the proxy at beginning and not be blocked by instagram