### PR TITLE
update get_link_from_media_id()

### DIFF
--- a/instabot/bot/bot_get.py
+++ b/instabot/bot/bot_get.py
@@ -401,6 +401,9 @@ def get_media_id_from_link(self, link):
 
 
 def get_link_from_media_id(self, media_id):
+    if (media_id.find("_")) :    #fetching media ids is sometimes resulting in user id being appended to it using "_"
+        new=media_id.split("_")
+        media_id=new[0]
     alphabet = {
         "-": 62,
         "1": 53,
@@ -469,7 +472,7 @@ def get_link_from_media_id(self, media_id):
     }
     result = ""
     while media_id:
-        media_id, char = media_id // 64, media_id % 64
+        media_id, char = int(media_id) // 64, int(media_id) % 64
         result += list(alphabet.keys())[list(alphabet.values()).index(char)]
     return "https://instagram.com/p/" + result[::-1] + "/"
 


### PR DESCRIPTION
* fetching media ids is sometimes resulting in user id being appended to it using "_"
added fix for it 
*media_id, char = int(media_id) // 64, int(media_id) % 64
added int conversion as media_id in char form will give type error when divided by int value .