### PR TITLE
Username placeholder

### DIFF
--- a/instabot/bot/bot_comment.py
+++ b/instabot/bot/bot_comment.py
@@ -62,6 +62,8 @@ def reply_to_comment(self, media_id, comment_text, parent_comment_id):
                 )
                 return False
         self.delay("comment")
+        comment_text = comment_text.\
+            replace("[[username]]", self.get_username_from_user_id(self.get_media_owner(media_id)))
         if comment_text[0] != "@":
             msg = ("A reply must start with mention, so '@' must be the "
                    "1st char, followed by the username you're replying to")

--- a/instabot/bot/bot_comment.py
+++ b/instabot/bot/bot_comment.py
@@ -62,8 +62,10 @@ def reply_to_comment(self, media_id, comment_text, parent_comment_id):
                 )
                 return False
         self.delay("comment")
-        comment_text = comment_text.\
-            replace("[[username]]", self.get_username_from_user_id(self.get_media_owner(media_id)))
+        media_owner = self.get_media_owner(media_id)
+        comment_text = comment_text.replace(
+            "[[username]]", self.get_username_from_user_id(media_owner)
+        )
         if comment_text[0] != "@":
             msg = ("A reply must start with mention, so '@' must be the "
                    "1st char, followed by the username you're replying to")


### PR DESCRIPTION
**Issue #1061 **

Added 1 line that replaces a string "[[username]]" in a comment with media owner's  username when replying. Could I add this when commenting a media or what should I change/improve?

Thanks.