### PR TITLE
show diff on failure of pre-commit's tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - name: "pre-commit"
       python: "3.7"
       env:
-        - PRE_COMMIT_CMD="pre-commit run --all-files"
+        - PRE_COMMIT_CMD="pre-commit run --all-files --show-diff-on-failure"
   allow_failures:
     - python: "3.8-dev"
     - python: "nightly"


### PR DESCRIPTION
This will make sure that when a pre-commit test fails, it prints the diffs.

In this way people do not need to install anything, just fix the problems that are printed in the Travis CI report.