### PR TITLE
Update Dockerfile to use pipenv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM python:3.7.2-slim
 
 WORKDIR /app
 
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
-
+COPY Pipfile .
+RUN pip install pipenv
+RUN pipenv install
 COPY . .
 
 VOLUME /app/examples/autopost/pics/
 
-CMD [ "python3", "example/multi_script_CLI.py" ]
+CMD [ "pipenv", "run", "python", "examples/multi_script_CLI.py"]


### PR DESCRIPTION
I went to use the Dockerfile and I noticed `requirements.txt` didn't exist anymore but there was a `Pipfile`.

So I updated to use that instead.