### PR TITLE
Fixed / Extended Logging

### DIFF
--- a/instabot/api/api.py
+++ b/instabot/api/api.py
@@ -46,7 +46,15 @@ PY2 = sys.version_info[0] == 2
 
 
 class API(object):
-    def __init__(self, device=None, base_path="", save_logfile=True, log_filename=None):
+    def __init__(
+        self,
+        device=None,
+        base_path="",
+        save_logfile=True,
+        log_filename=None,
+        loglevel_file=logging.INFO,
+        loglevel_stream=logging.DEBUG,
+    ):
         # Setup device and user_agent
         self.device = device or devices.DEFAULT_DEVICE
 
@@ -75,13 +83,15 @@ class API(object):
                 )
 
             fh = logging.FileHandler(filename=log_filename)
-            fh.setLevel(logging.INFO)
-            fh.setFormatter(logging.Formatter("%(asctime)s %(message)s"))
+            fh.setLevel(loglevel_file)
+            fh.setFormatter(
+                logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+            )
 
             self.logger.addHandler(fh)
 
         ch = logging.StreamHandler()
-        ch.setLevel(logging.DEBUG)
+        ch.setLevel(loglevel_stream)
         ch.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(message)s"))
 
         self.logger.addHandler(ch)
@@ -92,8 +102,6 @@ class API(object):
     def set_user(self, username, password, generate_all_uuids=True, set_device=True):
         self.username = username
         self.password = password
-
-        self.logger = logging.getLogger("[instabot_{}]".format(self.username))
 
         if set_device is True:
             self.set_device()

--- a/instabot/bot/bot.py
+++ b/instabot/bot/bot.py
@@ -1,5 +1,6 @@
 import atexit
 import datetime
+import logging
 import os
 import random
 import signal
@@ -177,6 +178,8 @@ class Bot(object):
         device=None,
         save_logfile=True,
         log_filename=None,
+        loglevel_file=logging.INFO,
+        loglevel_stream=logging.DEBUG,
         log_follow_unfollow=True,
     ):
         self.api = API(
@@ -184,6 +187,8 @@ class Bot(object):
             base_path=base_path,
             save_logfile=save_logfile,
             log_filename=log_filename,
+            loglevel_file=loglevel_file,
+            loglevel_stream=loglevel_stream,
         )
         self.log_follow_unfollow = log_follow_unfollow
         self.base_path = base_path


### PR DESCRIPTION
This PR should fix issue #1140 . 

The api.logger is no longer overwritten by set_user method to a new logger without any handlers/formatters/loglevels.

Furthermore it extends the configuration option for logging by introducing two new arguments for API and Bot (loglevel_file and loglevel_stream).

The defaults are the old values (DEBUG for stream; INFO for file) to preserve existing behavior. In my opinion this doesnt make sense, I'd expect the default to be the other way round (less output in the console; more for debugging in the file), but for backwards compatibility I didn't change that.
