### PR TITLE
fixed wrong endpoint

### DIFF
--- a/instabot/api/api.py
+++ b/instabot/api/api.py
@@ -1035,7 +1035,7 @@ class API(object):
         return self.get_username_info(self.user_id)
 
     def get_recent_activity(self):
-        return self.send_request("news/inbox")
+        return self.send_request("news/inbox/?limited_activity=true&show_su=true")
 
     def get_following_recent_activity(self):
         return self.send_request("news")


### PR DESCRIPTION
I also wrote an Instagram API but in C++ which you can see as it is open source too. When copying the endpoints from other repositories I recognized that it seems to me that the concerned endpoint in this pull request seems to cause problems. In my case the Instagram servers returned an error. I think it was status code 301 with no response body but I cannot assure that but I think it was that.

I assume that you copied from mpg25/Instagram-API and he does the same: https://github.com/mgp25/Instagram-API/blob/master/src/Request/People.php (line 128)

I tried out ping's endpoint with query string which worked for me: https://github.com/ping/instagram_private_api/blob/0fda0369ac02bc03d56f5f3f99bc9de2cc25ffaa/instagram_private_api/endpoints/misc.py#L77

It is your decision: For me your and mpg25's solution did not work.

PS: How did you manage to get Instagram's endpoints?! It is such a torture to do that. I tried it for like 3 week with every possible solution I found on the Internet and nothing worked. I described what I did in my wiki if you are interested: https://github.com/Spixmaster/instagram-private-api/wiki